### PR TITLE
Fixed compat issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+uv.lock
 
 # PyInstaller
 *.manifest

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,104 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = "World Model Lens"
+copyright = "2023, World Model Lens Team"
+author = "World Model Lens Team"
+release = "0.2.0"
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
+    "sphinx_autodoc_typehints",
+    "myst_parser",
+]
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "pydata_sphinx_theme"
+html_static_path = ["_static"]
+
+# PyData theme options
+html_theme_options = {
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/Bhavith-Chandra/WorldModelLens",
+            "icon": "fa-brands fa-github",
+        }
+    ],
+    "use_edit_page_button": True,
+    "show_toc_level": 2,
+    "navbar_start": ["navbar-logo"],
+    "navbar_center": ["navbar-nav"],
+    "navbar_end": ["navbar-icon-links"],
+    "navbar_persistent": ["search-button"],
+    "footer_start": ["copyright"],
+    "footer_end": [],
+}
+
+html_context = {
+    "github_user": "Bhavith-Chandra",
+    "github_repo": "WorldModelLens",
+    "github_version": "main",
+    "doc_path": "docs",
+}
+
+# -- Extension configuration --------------------------------------------------
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+]
+
+myst_heading_anchors = 3
+
+# Napoleon settings
+napoleon_google_docstring = True
+napoleon_numpy_docstring = True
+napoleon_include_init_with_doc = False
+napoleon_include_private_with_doc = False
+napoleon_include_special_with_doc = True
+napoleon_use_admonition_for_examples = False
+napoleon_use_admonition_for_notes = False
+napoleon_use_admonition_for_references = False
+napoleon_use_ivar = False
+napoleon_use_param = True
+napoleon_use_rtype = True
+napoleon_preprocess_types = False
+napoleon_type_aliases = None
+napoleon_attr_annotations = True
+
+# Autodoc settings
+autodoc_default_options = {
+    "members": True,
+    "member-order": "bysource",
+    "special-members": "__init__",
+    "undoc-members": True,
+    "exclude-members": "__weakref__",
+}
+
+# Type hints
+typehints_formatter = "sphinx_autodoc_typehints.format_annotation"
+
+# Intersphinx mapping
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "torch": ("https://pytorch.org/docs/stable/", None),
+    "matplotlib": ("https://matplotlib.org/stable/", None),
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ dev = [
 docs = [
     "sphinx",
     "sphinx-autodoc-typehints",
-    "sphinx.ext.napoleon",
     "myst-parser",
     "pydata-sphinx-theme",
 ]


### PR DESCRIPTION
Fixes this issue that occurs after executing `uv sync`:
```
Creating virtual environment at: .venv
  x No solution found when resolving dependencies for split (markers: python_full_version >= '3.14' and sys_platform
  | == 'win32'):
  `-> Because sphinx-ext-napoleon was not found in the package registry and world-model-lens[docs] depends on
      sphinx-ext-napoleon, we can conclude that world-model-lens[docs]'s requirements are unsatisfiable.
      And because your project requires world-model-lens[docs], we can conclude that your project's requirements are
      unsatisfiable.

      hint: While the active Python version is 3.13, the resolution failed for other Python versions supported by your
      project. Consider limiting your project's supported Python versions using `requires-python`.
```