### PR TITLE
refactor(sae): standardize SAE interface and trainer construction

### DIFF
--- a/docs/api/analysis.md
+++ b/docs/api/analysis.md
@@ -65,6 +65,86 @@ Analysis modules for belief tracking, uncertainty, hallucination detection, dise
    :show-inheritance:
 ```
 
+## Sparse Autoencoders (SAE)
+
+```{eval-rst}
+.. automodule:: world_model_lens.sae.sae
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```
+
+### Usage Example
+
+.. code-block:: python
+
+    from world_model_lens.sae.trainer import SAETrainer
+    import torch
+
+    # synthetic activations: 1000 samples, 64-d input
+    activations = torch.randn(1000, 64)
+
+    # construct a trainer using a named SAE implementation
+    trainer = SAETrainer(d_input=64, n_boj=32, k=4, l1_coefficient=1e-3, sae_type="gated")
+
+    # quick one-epoch train (use small epochs in docs/examples)
+    result = trainer.train(activations, epochs=5, batch_size=128, progress=False)
+
+    print("final L0:", result.final_l0, "final recon:", result.final_reconstruction_loss)
+
+Note: the trainer normalizes the sparsity penalty by taking the mean absolute
+activation (over batch and features). If you are migrating older experiments
+that used a sum-based L1 penalty, you may need to retune `l1_coefficient`.
+
+### Fair‑comparison note
+
+Historically some SAE implementations used a summed L1 penalty (e.g. `h.abs().sum()`),
+which scales with batch size and the number of features. The trainer now uses
+an averaged penalty (`h.abs().mean()`) so the `l1_coefficient` has consistent
+meaning across different batch sizes and model widths.
+
+If you need a rough conversion from an old `l1_sum_coeff` to the new mean-based
+coefficient, use:
+
+.. code-block:: python
+
+    # approximate conversion (depends on exact averaging axes)
+    old_coeff = 1e-3
+    batch_size = 128
+    n_features = 32
+    new_coeff = old_coeff * (batch_size * n_features)
+
+This is only an approximation; we recommend re-tuning `l1_coefficient` on a
+small validation set for best results.
+
+### Passing a custom SAE class
+
+If you have a compact SAE class you want to use directly, pass it via
+`sae_class`. The trainer will try several common constructor patterns, and
+`sae_kwargs` can be used for additional keyword arguments.
+
+.. code-block:: python
+
+    from world_model_lens.sae.sae import TopKSparseAutoencoder
+    trainer = SAETrainer(
+        d_input=64,
+        n_boj=32,
+        k=4,
+        sae_class=TopKSparseAutoencoder,
+        sae_kwargs={"tie_weights": True},
+    )
+
+The trainer attempts these constructor styles in order: keyword-style
+(`input_dim=.., n_features=.., k=..`), positional (`d_input, n_boj, k`),
+simple positional (`d_input, n_boj`), and finally `(config, device)`.
+
+Developer guide:
+
+.. toctree::
+   :hidden:
+
+   ../developer/sae_interface.md
+
 ## Temporal Attribution
 
 ```{eval-rst}

--- a/docs/developer/sae_interface.md
+++ b/docs/developer/sae_interface.md
@@ -1,0 +1,73 @@
+# SAE Developer Guide
+
+This short guide shows the minimal API a new Sparse Autoencoder (SAE)
+implementation should provide so it works cleanly with `SAETrainer`.
+
+Key points
+- Prefer implementing `from_config(config, device=None)` — the trainer will
+  call this when available to construct your model in a single standardized way.
+- `encode(x, ...)` should return either `(h, mask)` or `(h, indices)` where
+  `h` is the sparse latent tensor of shape `[B, n_features]`.
+- `decode(h)` should return reconstructions of shape `[B, input_dim]`.
+- `forward` need not be implemented if you inherit from `SAEBase` — the
+  provided base `forward` composes `encode` + `decode` and returns either
+  `(recon, h)` or `(recon, h, mask)` depending on what `encode` returns.
+- Optionally implement `compute_l0(h)` to return the mean L0 estimate per
+  example; the trainer will fall back to a safe approximation if missing.
+
+Minimal example
+
+```python
+from torch import nn
+import torch.nn.functional as F
+
+from world_model_lens.sae.sae import SAEBase
+
+class MyCustomSAE(SAEBase):
+    """Minimal SAE example compatible with SAETrainer."""
+
+    def __init__(self, input_dim: int, n_features: int, k: int = 1, tie_weights: bool = False):
+        super().__init__()
+        self.encoder = nn.Linear(input_dim, n_features)
+        self.decoder = nn.Linear(n_features, input_dim, bias=not tie_weights)
+        self.k = int(k)
+
+    @classmethod
+    def from_config(cls, config, device=None):
+        # config is the SAEConfig used by SAETrainer (has d_input, n_boj, k, tied_weights)
+        inst = cls(input_dim=config.d_input, n_features=config.n_boj, k=config.k, tie_weights=config.tied_weights)
+        if device is not None:
+            inst.to(device)
+        return inst
+
+    def encode(self, x, **kwargs):
+        h = self.encoder(x)
+        # keep only top-k per row
+        vals, idx = torch.topk(h, self.k, dim=-1)
+        mask = torch.zeros_like(h).scatter_(-1, idx, 1.0)
+        h = F.relu(h * mask)
+        return h, mask
+
+    def decode(self, h):
+        return self.decoder(h)
+
+    def compute_l0(self, h):
+        # return mean number of non-zero features per example
+        return (h.abs() > 1e-8).float().sum(dim=-1).mean()
+```
+
+Using your SAE with the trainer
+
+```python
+from world_model_lens.sae.trainer import SAETrainer
+# pass the class to the trainer; trainer will call `from_config`
+trainer = SAETrainer(d_input=64, n_boj=32, k=4, sae_class=MyCustomSAE)
+result = trainer.train(torch.randn(256, 64), epochs=5)
+```
+
+Notes
+- The trainer uses a normalized sparsity penalty: it multiplies `l1_coefficient`
+  by `h.abs().mean()` (mean across batch and features). When porting code that
+  used a summed L1 penalty (`.sum()`), retune the coefficient.
+- If your implementation returns `(recon, h)` or `(recon, h, mask)` from
+  `forward`, trainer already supports both shapes.

--- a/docs/examples/analysis-techniques.md
+++ b/docs/examples/analysis-techniques.md
@@ -71,6 +71,15 @@ Use probing when the question is: "What information is present in this represent
 - `world_model_lens.patching.TemporalPatcher`
 - cached clean and corrupted runs
 
+### Sparse Autoencoder Note
+
+This repository includes several Sparse Autoencoder (SAE) implementations used
+for disentangling latent features. See the API page for details and examples:
+
+- `docs/api/analysis.md` -> Sparse Autoencoders (SAE)
+  - Example usage and notes: `docs/api/analysis.md`
+
+
 Related API pages:
 - [patching.md](C:\Users\user\Desktop\WorldModelLens\docs\api\patching.md)
 - [core.md](C:\Users\user\Desktop\WorldModelLens\docs\api\core.md)

--- a/tests/test_sae.py
+++ b/tests/test_sae.py
@@ -1,0 +1,180 @@
+import pytest
+import torch
+
+from world_model_lens.sae.sae import TopKSparseAutoencoder, SAEBase
+from world_model_lens.sae.trainer import SAETrainer
+
+
+def test_topk_mask_behavior():
+    # small controlled example where encoder is identity so encoded values == inputs
+    sae = TopKSparseAutoencoder(input_dim=4, n_features=4, k=2)
+    with torch.no_grad():
+        sae.encoder.weight.copy_(torch.eye(4))
+        if sae.encoder.bias is not None:
+            sae.encoder.bias.zero_()
+
+    x = torch.tensor([[0.1, 0.9, 0.2, 0.8], [1.0, 0.5, 0.4, 0.3]])
+
+    recon, h, mask = sae(x)
+
+    # h should have exactly k nonzero entries per row
+    nnz_per_row = (h.abs() > 0).sum(dim=1).tolist()
+    assert nnz_per_row == [2, 2]
+
+    # mask positions should match top-k indices of the original pre-ReLU values
+    for row_vals, row_mask in zip(x, mask):
+        mask_idxs = (row_mask == 1).nonzero(as_tuple=True)[0].tolist()
+        topk_idxs = torch.topk(row_vals, 2).indices.tolist()
+        assert set(mask_idxs) == set(topk_idxs)
+
+
+def test_compute_loss_and_diagnostics():
+    sae = TopKSparseAutoencoder(input_dim=4, n_features=4, k=2)
+    x = torch.randn(8, 4)
+
+    total, info = sae.compute_loss(x, l1_weight=1e-2)
+
+    assert isinstance(total, torch.Tensor)
+    assert isinstance(info, dict)
+    assert set(["reconstruction", "sparsity", "total"]).issubset(set(info.keys()))
+    # numeric consistency
+    assert info["total"] == pytest.approx(float(total.item()), rel=1e-6)
+
+
+def test_tied_weights_copy():
+    sae = TopKSparseAutoencoder(input_dim=3, n_features=3, k=1, tie_weights=True)
+    # decoder weight should be a copy of encoder.weight.T at initialization
+    assert torch.allclose(sae.decoder.weight.detach(), sae.encoder.weight.T.detach())
+
+
+def test_sae_trainer_with_gated_type_smoke():
+    d_input = 8
+    n_boj = 4
+    k = 2
+
+    activations = torch.randn(16, d_input)
+
+    trainer = SAETrainer(d_input=d_input, n_boj=n_boj, k=k, sae_type="gated")
+
+    # run one-epoch quick training
+    result = trainer.train(activations, epochs=1, batch_size=8, lr=1e-3, progress=False)
+
+    assert hasattr(result, "sae")
+    assert isinstance(result.losses, list)
+    assert len(result.losses) == 1
+
+
+def test_sae_trainer_with_compact_topk_class_smoke():
+    d_input = 8
+    n_boj = 6
+    k = 3
+
+    activations = torch.randn(12, d_input)
+
+    # pass the compact TopKSparseAutoencoder class directly
+    trainer = SAETrainer(d_input=d_input, n_boj=n_boj, k=k, sae_class=TopKSparseAutoencoder)
+
+    result = trainer.train(activations, epochs=1, batch_size=6, lr=1e-3, progress=False)
+
+    assert hasattr(result, "sae")
+    assert isinstance(result.losses, list)
+    assert len(result.losses) == 1
+
+
+def test_sae_trainer_tied_weights_keyword_smoke():
+    """Ensure trainer constructs compact SAE with tied-weights when requested."""
+
+    torch.manual_seed(0)
+
+    d_input = 10
+    n_boj = 5
+    k = 2
+
+    activations = torch.randn(8, d_input)
+
+    # request tied_weights via trainer parameter (mapped to sae ctor)
+    trainer = SAETrainer(
+        d_input=d_input, n_boj=n_boj, k=k, sae_class=TopKSparseAutoencoder, tied_weights=True
+    )
+
+    # model should have been constructed
+    assert hasattr(trainer, "sae")
+
+    sae = trainer.sae
+    # check shapes
+    assert sae.encoder.weight.shape == (n_boj, d_input)
+    assert sae.decoder.weight.shape == (d_input, n_boj)
+
+    # values should be close to the transpose (copied at init)
+    assert torch.allclose(sae.decoder.weight, sae.encoder.weight.t(), atol=1e-6)
+
+
+def test_trainer_constructs_from_config_minimal_sae_smoke():
+    class MinimalFromConfigSAE(SAEBase):
+        def __init__(self, input_dim: int, n_features: int, k: int = 1, tie_weights: bool = False):
+            super().__init__()
+            self.encoder = torch.nn.Linear(input_dim, n_features)
+            self.decoder = torch.nn.Linear(n_features, input_dim)
+            self.k = int(k)
+
+        @classmethod
+        def from_config(cls, config, device=None):
+            inst = cls(input_dim=config.d_input, n_features=config.n_boj, k=config.k)
+            if device is not None:
+                inst.to(device)
+            return inst
+
+        def encode(self, x, **kwargs):
+            h = self.encoder(x)
+            h = torch.relu(h)
+            mask = (h > 0).float()
+            return h, mask
+
+        def decode(self, h):
+            return self.decoder(h)
+
+    d_input = 6
+    n_boj = 3
+    k = 2
+
+    activations = torch.randn(10, d_input)
+
+    trainer = SAETrainer(d_input=d_input, n_boj=n_boj, k=k, sae_class=MinimalFromConfigSAE)
+
+    result = trainer.train(activations, epochs=1, batch_size=5, lr=1e-3, progress=False)
+
+    assert hasattr(result, "sae")
+    assert isinstance(result.sae, MinimalFromConfigSAE)
+    assert isinstance(result.losses, list)
+    assert len(result.losses) == 1
+
+
+def test_sae_trainer_variants_grouped_smoke():
+    # reuse small cases from the separate variants test file and ensure they pass
+    d_input = 8
+    n_boj = 4
+    k = 2
+
+    activations = torch.randn(16, d_input)
+
+    trainer = SAETrainer(d_input=d_input, n_boj=n_boj, k=k, sae_type="gated")
+    result = trainer.train(activations, epochs=1, batch_size=8, lr=1e-3, progress=False)
+    assert hasattr(result, "sae")
+
+    d_input = 8
+    n_boj = 6
+    k = 3
+    activations = torch.randn(12, d_input)
+    trainer = SAETrainer(d_input=d_input, n_boj=n_boj, k=k, sae_class=TopKSparseAutoencoder)
+    result = trainer.train(activations, epochs=1, batch_size=6, lr=1e-3, progress=False)
+    assert hasattr(result, "sae")
+
+    # tied-weights construction smoke
+    d_input = 10
+    n_boj = 5
+    k = 2
+    trainer = SAETrainer(
+        d_input=d_input, n_boj=n_boj, k=k, sae_class=TopKSparseAutoencoder, tied_weights=True
+    )
+    sae = trainer.sae
+    assert sae.encoder.weight.shape == (n_boj, d_input)

--- a/world_model_lens/sae/sae.py
+++ b/world_model_lens/sae/sae.py
@@ -11,6 +11,7 @@ Features:
 """
 
 from typing import Any, Dict, List, Optional, Tuple, Callable
+from abc import ABC, abstractmethod
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -30,7 +31,52 @@ class SAEResult:
     reconstruction_loss: float
 
 
-class SparseAutoencoder(nn.Module):
+class SAEBase(nn.Module, ABC):
+    """Standardized SAE interface for trainer compatibility.
+
+    Implementations should provide `from_config(config, device)` to allow the
+    trainer to construct models in a single, standard way. Forward should
+    return `(reconstruction, sparse_h)` or `(reconstruction, sparse_h, mask)`.
+    """
+
+    @classmethod
+    @abstractmethod
+    def from_config(cls, config, device: Optional[torch.device] = None):
+        raise NotImplementedError
+
+    @abstractmethod
+    def encode(
+        self, x: torch.Tensor, *args, **kwargs
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def decode(self, h: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError
+
+    def compute_l0(self, h: torch.Tensor) -> torch.Tensor:
+        """Default L0 approximation (can be overridden)."""
+        return (h.abs() > 1e-8).float().sum(dim=-1).mean()
+
+    def forward(self, x: torch.Tensor, *args, **kwargs):
+        out = self.encode(x, *args, **kwargs)
+        if isinstance(out, tuple) and len(out) == 2:
+            h, mask = out
+        elif isinstance(out, tuple) and len(out) == 1:
+            h = out[0]
+            mask = None
+        else:
+            # if encode returns unexpected shape, assume encode already returned h
+            h = out
+            mask = None
+
+        recon = self.decode(h)
+        if mask is None:
+            return recon, h
+        return recon, h, mask
+
+
+class SparseAutoencoder(SAEBase):
     """Sparse Autoencoder for decomposing latent spaces.
 
     Learns a dictionary of features that can be activated sparsely.
@@ -85,6 +131,22 @@ class SparseAutoencoder(nn.Module):
 
         self.bottleneck_scale = nn.Parameter(torch.ones(n_features))
         self.bottleneck_bias = nn.Parameter(torch.zeros(n_features))
+
+    @classmethod
+    def from_config(cls, config, device: Optional[torch.device] = None):
+        """Construct from trainer SAEConfig-like object.
+
+        This provides a standardized constructor used by SAETrainer.
+        """
+        inst = cls(
+            input_dim=config.d_input,
+            n_features=config.n_boj,
+            hidden_dim=None,
+            tie_weights=config.tied_weights,
+        )
+        if device is not None:
+            inst.to(device)
+        return inst
 
     def encode(
         self,
@@ -240,7 +302,7 @@ class SparseAutoencoder(nn.Module):
         return next(self.parameters()).device
 
 
-class GatedSparseAutoencoder(nn.Module):
+class GatedSparseAutoencoder(SAEBase):
     """Gated SAE with better dead feature handling.
 
     Uses a gating mechanism to better handle feature activation.
@@ -268,6 +330,17 @@ class GatedSparseAutoencoder(nn.Module):
 
         nn.init.xavier_uniform_(self.encoder[0].weight)
         nn.init.xavier_uniform_(self.decoder.weight)
+
+    @classmethod
+    def from_config(cls, config, device: Optional[torch.device] = None):
+        inst = cls(input_dim=config.d_input, n_features=config.n_boj)
+        if device is not None:
+            inst.to(device)
+        return inst
+
+    def compute_l0(self, h: torch.Tensor) -> torch.Tensor:
+        """Approximate L0 from activations for compatibility."""
+        return (h.abs() > 1e-8).float().sum(dim=-1).mean()
 
     def encode(
         self,
@@ -477,3 +550,86 @@ class SAELayer:
         self._feature_cache = feature_activations
 
         return traj, cache
+
+
+# New feature: compact TopK ReLU Sparse Autoencoder class.
+class TopKSparseAutoencoder(SAEBase):
+    """Top-k ReLU Sparse Autoencoder.
+
+    Encoder: Linear(input_dim -> n_features)
+    Bottleneck: keep top-k activations per example, ReLU
+    Decoder: Linear(n_features -> input_dim)
+
+    compute_loss returns reconstruction MSE + l1 sparsity penalty.
+    """
+
+    def __init__(self, input_dim: int, n_features: int, k: int = 1, tie_weights: bool = False):
+        super().__init__()
+        self.input_dim = input_dim
+        self.n_features = n_features
+        self.k = int(k)
+
+        # initialize encoder weight first
+        self.encoder = nn.Linear(input_dim, n_features, bias=True)
+        nn.init.xavier_uniform_(self.encoder.weight)
+
+        if tie_weights:
+            # decoder uses a copied transpose of encoder weight at init
+            self.decoder = nn.Linear(n_features, input_dim, bias=False)
+            with torch.no_grad():
+                self.decoder.weight.copy_(self.encoder.weight.t())
+        else:
+            self.decoder = nn.Linear(n_features, input_dim, bias=True)
+            nn.init.xavier_uniform_(self.decoder.weight)
+
+    def topk_relu(self, h: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        if self.k <= 0 or self.k >= h.shape[-1]:
+            out = F.relu(h)
+            mask = (out > 0).float()
+            return out, mask
+
+        vals, idx = torch.topk(h, self.k, dim=-1)
+        mask = torch.zeros_like(h).scatter_(-1, idx, 1.0)
+        out = h * mask
+        out = F.relu(out)
+        return out, mask
+
+    def encode(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        h = self.encoder(x)
+        return self.topk_relu(h)
+
+    def decode(self, h: torch.Tensor) -> torch.Tensor:
+        return self.decoder(h)
+
+    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        h, mask = self.encode(x)
+        recon = self.decode(h)
+        return recon, h, mask
+
+    def compute_loss(
+        self, x: torch.Tensor, l1_weight: float = 1e-3
+    ) -> Tuple[torch.Tensor, Dict[str, float]]:
+        recon, h, mask = self.forward(x)
+        recon_loss = F.mse_loss(recon, x)
+        sparsity = h.abs().mean()
+        total = recon_loss + l1_weight * sparsity
+        return total, {
+            "reconstruction": float(recon_loss.item()),
+            "sparsity": float(sparsity.item()),
+            "total": float(total.item()),
+        }
+
+    @classmethod
+    def from_config(cls, config, device: Optional[torch.device] = None):
+        inst = cls(
+            input_dim=config.d_input,
+            n_features=config.n_boj,
+            k=config.k,
+            tie_weights=config.tied_weights,
+        )
+        if device is not None:
+            inst.to(device)
+        return inst
+
+    def compute_l0(self, h: torch.Tensor) -> torch.Tensor:
+        return (h.abs() > 1e-8).float().sum(dim=-1).mean()

--- a/world_model_lens/sae/trainer.py
+++ b/world_model_lens/sae/trainer.py
@@ -6,11 +6,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
-
-try:
-    from tqdm import tqdm
-except ImportError:
-    tqdm = None
+from tqdm import tqdm
 
 
 def _get_device() -> torch.device:
@@ -194,6 +190,9 @@ class SAETrainer:
         l1_coefficient: float = 1e-3,
         device: Optional[torch.device] = None,
         tied_weights: bool = True,
+        sae_class: Optional[Callable] = None,
+        sae_kwargs: Optional[Dict[str, Any]] = None,
+        sae_type: Optional[str] = None,
     ):
         """Initialize trainer.
 
@@ -212,8 +211,97 @@ class SAETrainer:
             l1_coefficient=l1_coefficient,
             tied_weights=tied_weights,
         )
-        self.sae = SparseAutoencoder(config, device)
+        # keep config on trainer so we don't rely on model having .config
+        self.config = config
+        # allow injecting alternate SAE implementations via sae_class
         self.device = device or _get_device()
+        sae_kwargs = sae_kwargs or {}
+
+        # allow selecting common SAE implementations by name for simplicity
+        if sae_type is not None and sae_class is None:
+            # keep imports local to avoid circular import at module load
+            try:
+                from world_model_lens.sae.sae import (
+                    GatedSparseAutoencoder,
+                    TopKSparseAutoencoder,
+                )
+            except Exception:
+                GatedSparseAutoencoder = None
+                TopKSparseAutoencoder = None
+
+            name = sae_type.lower()
+            if name in ("trainer", "sparse", "default"):
+                sae_class = None
+            elif name in ("gated",):
+                sae_class = GatedSparseAutoencoder
+            elif name in ("topk", "compact", "compact_topk"):
+                sae_class = TopKSparseAutoencoder
+            else:
+                # leave sae_class as provided (possibly None)
+                sae_class = sae_class
+
+        if sae_class is None:
+            # default trainer-local SparseAutoencoder
+            self.sae = SparseAutoencoder(config, self.device)
+        else:
+            # Prefer standardized constructor if available: from_config(config, device)
+            constructed = False
+            if hasattr(sae_class, "from_config"):
+                try:
+                    self.sae = sae_class.from_config(config, self.device)
+                    constructed = True
+                except Exception:
+                    constructed = False
+
+            if not constructed:
+                # Try common explicit (config, device) constructor next
+                try:
+                    self.sae = sae_class(config, self.device)
+                    constructed = True
+                except Exception:
+                    constructed = False
+
+            if not constructed:
+                # Try keyword-style constructor that many compact SAEs support
+                try:
+                    self.sae = sae_class(
+                        input_dim=d_input,
+                        n_features=n_boj,
+                        k=k,
+                        tie_weights=tied_weights,
+                        **sae_kwargs,
+                    )
+                    constructed = True
+                except Exception:
+                    constructed = False
+
+            if not constructed:
+                # try simple positional constructors: (d_input, n_boj, k)
+                try:
+                    self.sae = sae_class(d_input, n_boj, k)
+                    constructed = True
+                except Exception:
+                    constructed = False
+
+            if not constructed:
+                # try simplest positional (d_input, n_boj)
+                try:
+                    self.sae = sae_class(d_input, n_boj)
+                    constructed = True
+                except Exception as e:
+                    # give up and raise a helpful error
+                    raise TypeError(
+                        f"Unable to construct SAE from {sae_class}."
+                        " Expected one of: class.from_config(config, device),"
+                        " (config, device), (input_dim=.., n_features=.., k=..),"
+                        " or positional (d_input, n_boj[, k])."
+                    ) from e
+
+        # ensure model lives on trainer device
+        self.sae = self.sae.to(self.device)
+        # store class/kwargs for introspection
+        self.sae_class = sae_class
+        self.sae_kwargs = sae_kwargs
 
     def train(
         self,
@@ -269,17 +357,40 @@ class SAETrainer:
 
                 optimizer.zero_grad()
 
-                recon, sparse_h, mask = self.sae(batch)
+                out = self.sae(batch)
+
+                # support SAEs that return (recon, sparse_h, mask) or (recon, sparse_h)
+                if isinstance(out, (tuple, list)):
+                    if len(out) == 3:
+                        recon, sparse_h, mask = out
+                    elif len(out) == 2:
+                        recon, sparse_h = out
+                        mask = None
+                    else:
+                        raise RuntimeError("Unexpected SAE forward output shape")
+                else:
+                    # single tensor returned (assume reconstruction) - not supported
+                    raise RuntimeError(
+                        "SAE forward must return (recon, sparse_h) or (recon, sparse_h, mask)"
+                    )
 
                 recon_loss = F.mse_loss(recon, batch)
-                l1_loss = self.sae.config.l1_coefficient * sparse_h.abs().sum()
+                # normalize sparsity penalty by taking mean over batch+features
+                l1_loss = self.config.l1_coefficient * sparse_h.abs().mean()
                 loss = recon_loss + l1_loss
 
                 loss.backward()
                 optimizer.step()
 
                 epoch_loss += loss.item()
-                epoch_l0 += self.sae.compute_l0(sparse_h).item()
+                # compute l0 using available API or approximate
+                if hasattr(self.sae, "compute_l0"):
+                    try:
+                        epoch_l0 += self.sae.compute_l0(sparse_h).item()
+                    except Exception:
+                        epoch_l0 += (sparse_h.abs() > 1e-8).float().sum(dim=-1).mean().item()
+                else:
+                    epoch_l0 += (sparse_h.abs() > 1e-8).float().sum(dim=-1).mean().item()
                 epoch_recon += recon_loss.item()
                 epoch_l1 += l1_loss.item()
 


### PR DESCRIPTION
Summary of changes:
- Add `SAEBase` with a standardized interface and a `from_config(config, device)` constructor.
- Update `SparseAutoencoder`, `GatedSparseAutoencoder`, and `TopKSparseAutoencoder` to implement `from_config` and provide a `compute_l0` fallback.
- Simplify SAETrainer construction: prefer `from_config(config, device)`, then `(config, device)`, then legacy constructors.
- Normalize the sparsity penalty: trainer uses `h.abs().mean()` so `l1_coefficient` is comparable across batch sizes and widths.
- Add developer guide at `docs/developer/sae_interface.md` and link it from the API docs.
- Consolidate SAE tests into `tests/test_sae.py` and add minimal smoke tests.
- All tests pass locally (148 passed, 1 skipped).