### PR TITLE
Add Modular I-JEPA Surprise Timeline and OOD Detection on Predictor Latents

### DIFF
--- a/tests/test_belief_analyzer.py
+++ b/tests/test_belief_analyzer.py
@@ -5,6 +5,8 @@ import pytest
 
 from world_model_lens import HookedWorldModel, WorldModelConfig
 from world_model_lens.analysis.belief_analyzer import BeliefAnalyzer
+from world_model_lens.analysis.uncertainty import UncertaintyQuantifier
+from world_model_lens.backends.ijepa_adapter import IJEPAAdapter
 from tests.conftest import SimpleTestAdapter
 
 
@@ -47,3 +49,43 @@ class TestBeliefAnalyzer:
         """Test disentanglement_score method exists."""
         assert hasattr(analyzer, "disentanglement_score")
         assert callable(analyzer.disentanglement_score)
+
+    def test_ijepa_surprise_timeline(self):
+        """Test surprise_timeline with I-JEPA cosine distance."""
+
+        config = WorldModelConfig(backend="ijepa", d_embed=128, predictor_embed_dim=192)
+        adapter = IJEPAAdapter(config)
+        wm = HookedWorldModel(adapter=adapter, config=config)
+        analyzer = BeliefAnalyzer(wm)
+
+        # Create dummy input for IJEPA (images)
+        batch_size = 2
+        obs = torch.randn(batch_size, 3, 224, 224)  # RGB images
+
+        # Run with cache
+        with torch.no_grad():
+            _, cache = wm.run_with_cache(obs)
+
+        result = analyzer.surprise_timeline(cache)
+
+        assert result.kl_sequence is not None
+        assert len(result.kl_sequence) >= 1  # At least one timestep
+        assert result.mean_surprise >= 0  # cosine distance is 0-2
+
+    def test_uncertainty_fit_and_score_ood(self):
+        """Test OOD fitting and scoring."""
+
+        quantifier = UncertaintyQuantifier()
+
+        # Mock in-distribution latents
+        id_latents = [torch.randn(4, 32) for _ in range(10)]  # 10 samples, 4 patches, 32 dim
+
+        quantifier.fit_latent_distribution(id_latents)
+        assert quantifier.is_ood_fitted
+
+        # Mock OOD latents
+        ood_latents = [torch.randn(4, 32) for _ in range(5)]
+
+        scores = quantifier.score_ood_latents(ood_latents)
+        assert scores.shape == (5,)
+        assert (scores >= 0).all()

--- a/world_model_lens/analysis/belief_analyzer.py
+++ b/world_model_lens/analysis/belief_analyzer.py
@@ -223,10 +223,11 @@ class BeliefAnalyzer:
         obs_seq: Optional[torch.Tensor] = None,
         decoder: Optional[Any] = None,
     ) -> SurpriseResult:
-        """Compute surprise (KL divergence) timeline.
+        """Compute surprise (KL divergence or cosine distance) timeline.
 
         Works with ANY world model - computes KL between posterior and prior
-        latents when both are available.
+        latents when both are available, or cosine distance for I-JEPA predictor
+        vs target encoder outputs.
 
         Args:
             cache: ActivationCache from run_with_cache.
@@ -236,41 +237,58 @@ class BeliefAnalyzer:
         Returns:
             SurpriseResult with timeline and statistics.
         """
-        kl_vals = []
-        peaks = []
         timesteps = sorted(cache.timesteps)
 
-        for t in timesteps:
-            try:
-                z_post = cache["z_posterior", t]
-                z_prior = cache["z_prior", t]
+        if (
+            "predictor_out" in cache.component_names
+            and "target_encoder_out" in cache.component_names
+        ):
+            # I-JEPA cosine distance
+            dist_vals = []
+            for t in timesteps:
+                try:
+                    pred_out = cache["predictor_out", t]
+                    targ_out = cache["target_encoder_out", t]
+                    # Assume pred_out and targ_out are [num_patches, dim]
+                    similarities = torch.nn.functional.cosine_similarity(pred_out, targ_out, dim=-1)
+                    distances = 1 - similarities
+                    dist_vals.append(distances.mean().item())
+                except (KeyError, TypeError):
+                    dist_vals.append(0.0)
+            kl_tensor = torch.tensor(dist_vals)
+        else:
+            # Original KL divergence
+            kl_vals = []
+            for t in timesteps:
+                try:
+                    z_post = cache["z_posterior", t]
+                    z_prior = cache["z_prior", t]
 
-                if z_post.shape != z_prior.shape or z_post.dim() <= 1:
+                    if z_post.shape != z_prior.shape or z_post.dim() <= 1:
+                        kl_vals.append(0.0)
+                        continue
+
+                    p = z_post.clamp(min=1e-8)
+                    q = z_prior.clamp(min=1e-8)
+                    p = p / p.sum(dim=-1, keepdim=True)
+                    q = q / q.sum(dim=-1, keepdim=True)
+                    kl = (p * (p.log() - q.log())).sum().item()
+                    kl_vals.append(kl)
+                except (KeyError, TypeError):
                     kl_vals.append(0.0)
-                    continue
+            kl_tensor = torch.tensor(kl_vals)
 
-                p = z_post.clamp(min=1e-8)
-                q = z_prior.clamp(min=1e-8)
-                p = p / p.sum(dim=-1, keepdim=True)
-                q = q / q.sum(dim=-1, keepdim=True)
-                kl = (p * (p.log() - q.log())).sum().item()
-                kl_vals.append(kl)
-            except (KeyError, TypeError):
-                kl_vals.append(0.0)
-
-        kl_tensor = torch.tensor(kl_vals)
-
-        mean_surprise = kl_tensor.mean().item() if len(kl_vals) > 0 else 0.0
-        max_idx = kl_tensor.argmax().item() if len(kl_vals) > 0 else 0
-        threshold = mean_surprise + kl_tensor.std().item() if len(kl_vals) > 0 else 0
-        peaks = [(i, v) for i, v in enumerate(kl_vals) if v > threshold]
+        mean_surprise = kl_tensor.mean().item() if len(kl_tensor) > 0 else 0.0
+        max_idx = int(kl_tensor.argmax().item()) if len(kl_tensor) > 0 else 0
+        threshold = mean_surprise + kl_tensor.std().item() if len(kl_tensor) > 0 else 0
+        peaks = [(i, v.item()) for i, v in enumerate(kl_tensor) if v > threshold]
 
         return SurpriseResult(
             kl_sequence=kl_tensor,
             peaks=peaks,
             mean_surprise=mean_surprise,
             max_surprise_timestep=max_idx,
-            max_surprise_value=kl_vals[max_idx] if kl_vals else 0.0,
+            max_surprise_value=kl_tensor[max_idx].item() if len(kl_tensor) > 0 else 0.0,
         )
 
     def concept_search(

--- a/world_model_lens/analysis/uncertainty.py
+++ b/world_model_lens/analysis/uncertainty.py
@@ -31,6 +31,8 @@ class UncertaintyResult:
     epistemic_uncertainty: float | None = None
     aleatoric_uncertainty: float | None = None
     total_uncertainty: float | None = None
+    ood_scores: torch.Tensor | None = None
+    is_ood_fitted: bool = False
 
 
 class UncertaintyQuantifier:
@@ -41,6 +43,7 @@ class UncertaintyQuantifier:
     - Dropout-based (Bayesian)
     - Confidence-based
     - Disagreement-based
+    - Latent-based OOD detection (fit distribution on predictor latents)
     """
 
     def __init__(self, wm: Optional["HookedWorldModel"] = None):
@@ -233,6 +236,39 @@ class UncertaintyQuantifier:
             disagreement = predictions.var(dim=0).mean()
 
         return disagreement.item()
+
+    def fit_latent_distribution(self, latents: list[torch.Tensor]) -> None:
+        """Fit distribution on in-distribution predictor latents.
+
+        Args:
+            latents: List of latent tensors, each [num_patches, dim]
+        """
+        # Aggregate per latent: mean over patches
+        aggregated = [latent.mean(dim=0) for latent in latents]  # list of [dim]
+        latents_tensor = torch.stack(aggregated)  # [n_samples, dim]
+        self.id_mean = latents_tensor.mean(dim=0)
+        self.id_cov = torch.cov(latents_tensor.T) + 1e-6 * torch.eye(
+            latents_tensor.shape[1]
+        )  # regularization
+        self.is_ood_fitted = True
+
+    def score_ood_latents(self, latents: list[torch.Tensor]) -> torch.Tensor:
+        """Score OOD latents using Mahalanobis distance.
+
+        Args:
+            latents: List of latent tensors
+
+        Returns:
+            Scores tensor [n_samples]
+        """
+        if not self.is_ood_fitted:
+            raise ValueError("Distribution not fitted")
+        aggregated = [latent.mean(dim=0) for latent in latents]
+        latents_tensor = torch.stack(aggregated)  # [n_samples, dim]
+        diff = latents_tensor - self.id_mean
+        inv_cov = torch.inverse(self.id_cov)
+        mahal = torch.einsum("bi,ij,bj->b", diff, inv_cov, diff)
+        return mahal.sqrt()
 
     def run_full_analysis(
         self,

--- a/world_model_lens/analysis/uncertainty.py
+++ b/world_model_lens/analysis/uncertainty.py
@@ -24,14 +24,14 @@ if TYPE_CHECKING:
 class UncertaintyResult:
     """Result of uncertainty analysis."""
 
-    mean_prediction: torch.Tensor | None = None
-    variance: torch.Tensor | None = None
-    entropy: torch.Tensor | None = None
-    confidence: torch.Tensor | None = None
-    epistemic_uncertainty: float | None = None
-    aleatoric_uncertainty: float | None = None
-    total_uncertainty: float | None = None
-    ood_scores: torch.Tensor | None = None
+    mean_prediction: Optional[torch.Tensor] = None
+    variance: Optional[torch.Tensor] = None
+    entropy: Optional[torch.Tensor] = None
+    confidence: Optional[torch.Tensor] = None
+    epistemic_uncertainty: Optional[float] = None
+    aleatoric_uncertainty: Optional[float] = None
+    total_uncertainty: Optional[float] = None
+    ood_scores: Optional[torch.Tensor] = None
     is_ood_fitted: bool = False
 
 


### PR DESCRIPTION
This PR implements modular support for I-JEPA (Image-based Joint-Embedding Predictive Architecture) in the surprise analysis and adds out-of-distribution (OOD) detection capabilities on predictor latents.
#### Key Changes:
1. **Modular `surprise_timeline()` in `BeliefAnalyzer`**:
   - Detects I-JEPA models by checking for `predictor_out` and `target_encoder_out` in the activation cache.
   - For I-JEPA: Computes cosine distance (1 - cosine similarity) between predictor outputs and target encoder outputs per patch position, aggregates over patches per timestep.
   - Falls back to original KL divergence computation for other models (e.g., RL world models).
   - Updated docstring to reflect modular support.
2. **OOD Detection in `UncertaintyQuantifier`**:
   - Added `fit_latent_distribution()`: Fits a multivariate Gaussian distribution on in-distribution predictor latents (aggregated over patches), with regularization for numerical stability.
   - Added `score_ood_latents()`: Scores OOD latents using Mahalanobis distance under the fitted distribution.
   - Extended `UncertaintyResult` dataclass with `ood_scores` (tensor of scores) and `is_ood_fitted` (bool flag).
3. **Tests**:
   - Added `test_ijepa_surprise_timeline`: Uses real `IJEPAAdapter` to test cosine distance computation on actual predictor and target outputs.
   - Added `test_uncertainty_fit_and_score_ood`: Tests distribution fitting and OOD scoring.
   - Moved all imports to top-level in test files for consistency.
#### Motivation:
- Enables analysis of I-JEPA models without KL priors/posteriors by using cosine distance as a surprise metric.
- Provides OOD detection across image domains (e.g., ImageNet in-distribution) using predictor latents.
- Maintains modularity for future model additions.
#### Files Modified:
- `world_model_lens/analysis/belief_analyzer.py`: Updated `surprise_timeline()`.
- `world_model_lens/analysis/uncertainty.py`: Added OOD methods, extended `UncertaintyResult`.
- `tests/test_belief_analyzer.py`: Added new tests, moved imports.