### PR TITLE
fix ijepa examples: hook propagation, predictor_embed_dim, torch.tensor

### DIFF
--- a/examples/ijepa/attribution_graph.py
+++ b/examples/ijepa/attribution_graph.py
@@ -87,7 +87,7 @@ def visualize_research_ijepa(target_ids=None, k=6, layout_mode="importance"):
     raw_img = get_sample_image()
     img_tensor = preprocess_image(raw_img)
     
-    config = WorldModelConfig(backend="ijepa", d_embed=192, n_layers=6, n_heads=3, predictor_embed_dim=192)
+    config = WorldModelConfig(backend="ijepa", d_embed=192, n_layers=6, n_heads=3, predictor_embed_dim=384)
     adapter = IJEPAAdapter(config)
     
     import os

--- a/examples/ijepa/causal_evaluator.py
+++ b/examples/ijepa/causal_evaluator.py
@@ -205,7 +205,7 @@ def plot_faithfulness(results_list, metric="mse"):
 if __name__ == "__main__":
     import os
     
-    config = WorldModelConfig(backend="ijepa", d_embed=192, n_layers=6, n_heads=3, predictor_embed_dim=192)
+    config = WorldModelConfig(backend="ijepa", d_embed=192, n_layers=6, n_heads=3, predictor_embed_dim=384)
     model = IJEPAAdapter(config)
     
     checkpoint_path = "ijepa_mini.pth"

--- a/examples/ijepa/circuit_view.py
+++ b/examples/ijepa/circuit_view.py
@@ -19,7 +19,7 @@ class ThresholdCircuitVisualizer:
         self.raw_img = get_sample_image()
         self.img_tensor = preprocess_image(self.raw_img)
         
-        config = WorldModelConfig(backend="ijepa", d_embed=192, n_layers=6, n_heads=3, predictor_embed_dim=192)
+        config = WorldModelConfig(backend="ijepa", d_embed=192, n_layers=6, n_heads=3, predictor_embed_dim=384)
         self.adapter = IJEPAAdapter(config)
         
         checkpoint_path = "ijepa_mini.pth"

--- a/examples/ijepa/counterfactual_analysis.py
+++ b/examples/ijepa/counterfactual_analysis.py
@@ -13,7 +13,7 @@ import os
 
 class IJEPACounterfactualAnalyzer:
     def __init__(self):
-        config = WorldModelConfig(backend="ijepa", d_embed=192, n_layers=6, n_heads=3, predictor_embed_dim=192)
+        config = WorldModelConfig(backend="ijepa", d_embed=192, n_layers=6, n_heads=3, predictor_embed_dim=384)
         self.adapter = IJEPAAdapter(config)
         checkpoint_path = "ijepa_mini.pth"
         if os.path.exists(checkpoint_path):

--- a/examples/ijepa/formal_circuits.py
+++ b/examples/ijepa/formal_circuits.py
@@ -23,7 +23,7 @@ class FormalCircuitDiscoverer:
             d_embed=192,
             n_layers=6,
             n_heads=3,
-            predictor_embed_dim=192,
+            predictor_embed_dim=384,
         )
 
         self.adapter = IJEPAAdapter(self.config)

--- a/examples/ijepa/interactive_explorer.py
+++ b/examples/ijepa/interactive_explorer.py
@@ -25,7 +25,7 @@ class AttributionExplorer:
         self.raw_img = get_sample_image()
         self.img_tensor = preprocess_image(self.raw_img)
         
-        config = WorldModelConfig(backend="ijepa", d_embed=384, n_layers=6, n_heads=6)
+        config = WorldModelConfig(backend="ijepa", d_embed=192, n_layers=6, n_heads=3, predictor_embed_dim=384, predictor_depth=4, predictor_heads=6)
         self.adapter = IJEPAAdapter(config)
         
         # Load weights if they exist (best effort)

--- a/examples/ijepa/progressive_build.py
+++ b/examples/ijepa/progressive_build.py
@@ -14,7 +14,7 @@ config = WorldModelConfig(
     d_embed=192,
     n_layers=6,
     n_heads=3,
-    predictor_embed_dim=192
+    predictor_embed_dim=384
 )
 
 

--- a/examples/ijepa/structural_circuits.py
+++ b/examples/ijepa/structural_circuits.py
@@ -15,7 +15,7 @@ class IJEPAStructuralTracer:
         self.raw_img = get_sample_image()
         self.img_tensor = preprocess_image(self.raw_img)
         
-        config = WorldModelConfig(backend="ijepa", d_embed=192, n_layers=6, n_heads=3)
+        config = WorldModelConfig(backend="ijepa", d_embed=192, n_layers=6, n_heads=3, predictor_embed_dim=384, predictor_depth=4, predictor_heads=6)
         self.adapter = IJEPAAdapter(config)
         
         checkpoint_path = "ijepa_mini.pth"

--- a/world_model_lens/backends/ijepa_adapter.py
+++ b/world_model_lens/backends/ijepa_adapter.py
@@ -504,6 +504,8 @@ class IJEPAAdapter(BaseModelAdapter):
         if self.last_target_ids is None:
             self.last_target_ids = list(range(10))
 
+        self.predictor.hooks = self.hooks
+        self.predictor.current_timestep = self.current_timestep
         pred_latents = self.predictor(h, self.last_context_ids, self.last_target_ids)
         return pred_latents
 

--- a/world_model_lens/backends/ijepa_adapter.py
+++ b/world_model_lens/backends/ijepa_adapter.py
@@ -433,7 +433,7 @@ class IJEPAAdapter(BaseModelAdapter):
         context_latents = self.context_encoder(obs, patch_ids=context_ids)  # [B, N_context, C]
 
         # 4. Predict targets block-wise as per the original I-JEPA paper
-        total_loss = torch.Tensor(0.0, device=obs.device)
+        total_loss = torch.tensor(0.0, device=obs.device)
         for block_ids in target_ids_list:
             target_gt_block = target_reps[:, block_ids, :]
             predicted_block = self.predictor(context_latents, context_ids, block_ids)


### PR DESCRIPTION
# Summary
- Fix hooks not firing in `structural_circuits.py`: sync `self.predictor.hooks` in `dynamics()` before predictor call
- Fix `predictor_embed_dim=192→384` across all ijepa examples to match checkpoint architecture
- Fix `torch.Tensor(0.0)` → `torch.tensor(0.0)` in `ijepa_adapter.py` (uppercase constructor rejects floats)

All ijepa examples now run end-to-end without errors