### PR TITLE
feat(core): return WorldTrajectory and LatentTrajectory

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -91,7 +91,7 @@ examples/causal-analysis
 ### Forward pass with activation caching
 
 ```python
-traj, cache = wm.run_with_cache(obs_seq, action_seq)
+world_traj, latent_traj, cache = wm.run_with_cache(obs_seq, action_seq)
 h_t = cache["h", 0]
 z_t = cache["z_posterior", 0]
 ```
@@ -99,7 +99,7 @@ z_t = cache["z_posterior", 0]
 ### Imagination from an existing state
 
 ```python
-imagined = wm.imagine(start_state=traj.states[5], horizon=20)
+imagined_world, imagined_latent = wm.imagine(start_state=latent_traj.states[5], horizon=20)
 ```
 
 ### Analysis after collection

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -77,7 +77,7 @@ wm = HookedWorldModel(adapter=MyModel(config), config=config)
 
 ```python
 observations = torch.randn(20, 128)  # 20 timesteps
-traj, cache = wm.run_with_cache(observations)
+world_traj, latent_traj, cache = wm.run_with_cache(observations)
 
 # Inspect any activation at any timestep
 z_5 = cache["z_posterior", 5]

--- a/examples/01_quickstart.py
+++ b/examples/01_quickstart.py
@@ -17,6 +17,7 @@ OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 from world_model_lens import HookedWorldModel, WorldModelConfig
 from world_model_lens.backends.dreamerv3 import DreamerV3Adapter
+from world_model_lens.envs import GymnasiumAdapter
 from world_model_lens.visualization import plot_quickstart_dashboard
 
 
@@ -29,8 +30,8 @@ def main():
         d_h=256,
         n_cat=32,
         n_cls=32,
-        d_action=4,
-        d_obs=12288,
+        d_action=1,
+        d_obs=3,
     )
     print(f"\n[1] Config created: d_h={cfg.d_h}, n_cat={cfg.n_cat}, n_cls={cfg.n_cls}")
 
@@ -40,10 +41,22 @@ def main():
     wm = HookedWorldModel(adapter=adapter, config=cfg, name="quickstart")
     print("\n[3] HookedWorldModel wrapper created")
 
-    T, C, H, W = 10, 3, 64, 64
-    obs_seq = torch.randn(T, C, H, W)
-    action_seq = torch.randn(T, cfg.d_action)
-    print(f"\n[4] Created fake data: obs={obs_seq.shape}, actions={action_seq.shape}")
+    env = GymnasiumAdapter("Pendulum-v1")
+    obs, _ = env.reset(seed=42)
+    obs_list, action_list = [], []
+    T = 10
+    for _ in range(T):
+        action = env.action_space.sample()
+        obs_list.append(torch.from_numpy(obs).float())
+        action_list.append(torch.from_numpy(action).float())
+        result = env.step(action)
+        obs = result.observation
+        if result.done:
+            break
+    env.close()
+    obs_seq = torch.stack(obs_list)
+    action_seq = torch.stack(action_list)
+    print(f"\n[4] Collected {len(obs_list)} steps from Pendulum-v1: obs={obs_seq.shape}, actions={action_seq.shape}")
 
     traj, cache = wm.run_with_cache(obs_seq, action_seq)
     print(f"\n[5] Forward pass complete!")

--- a/examples/01_quickstart.py
+++ b/examples/01_quickstart.py
@@ -58,7 +58,7 @@ def main():
     action_seq = torch.stack(action_list)
     print(f"\n[4] Collected {len(obs_list)} steps from Pendulum-v1: obs={obs_seq.shape}, actions={action_seq.shape}")
 
-    traj, cache = wm.run_with_cache(obs_seq, action_seq)
+    world_traj, latent_traj, cache = wm.run_with_cache(obs_seq, action_seq)
     print(f"\n[5] Forward pass complete!")
     print(f"    Trajectory length: {traj.length}")
     print(f"    Cache keys: {cache.component_names}")
@@ -69,7 +69,7 @@ def main():
     print(f"    h_t shape: {h_t.shape}")
     print(f"    z_posterior shape: {z_posterior.shape}")
 
-    imagined = wm.imagine(start_state=traj.states[5], horizon=20)
+    imagined_world, imagined_latent = wm.imagine(start_state=latent_traj.states[5], horizon=20)
     print(f"\n[7] Imagination complete: {imagined.length} steps")
 
     print("\n[8] Building visualization dashboard...")

--- a/examples/02_probing.py
+++ b/examples/02_probing.py
@@ -58,7 +58,7 @@ def main():
         obs_seq = torch.stack(obs_list)
         action_seq = torch.stack(action_list)
 
-        traj, cache = wm.run_with_cache(obs_seq, action_seq)
+        world_traj, latent_traj, cache = wm.run_with_cache(obs_seq, action_seq)
 
         z_posterior = cache["z_posterior"]
         z_flat = z_posterior.flatten(1) if z_posterior.dim() > 2 else z_posterior

--- a/examples/02_probing.py
+++ b/examples/02_probing.py
@@ -21,6 +21,7 @@ OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 from world_model_lens import HookedWorldModel, LatentProber, WorldModelConfig
 from world_model_lens.backends.dreamerv3 import DreamerV3Adapter
+from world_model_lens.envs import GymnasiumAdapter
 from world_model_lens.visualization import plot_probing_dashboard
 
 
@@ -29,7 +30,9 @@ def main():
     print("World Model Lens - Linear Probing Example")
     print("=" * 60)
 
-    cfg = WorldModelConfig(d_h=128, n_cat=16, n_cls=16, d_action=4, d_obs=12288)
+    # Pendulum-v1 obs is (cos θ, sin θ, θ̇) so d_obs=3 and d_action=1 — the DreamerV3Adapter
+    # will automatically use its MLP vector encoder instead of the CNN branch.
+    cfg = WorldModelConfig(d_h=128, n_cat=16, n_cls=16, d_action=1, d_obs=3)
     adapter = DreamerV3Adapter(cfg)
     wm = HookedWorldModel(adapter=adapter, config=cfg)
 
@@ -38,9 +41,22 @@ def main():
     all_activations = []
     all_labels = []
 
+    # Each episode resets with a different seed so the 5 trajectories have genuinely
+    # distinct starting states — probes trained on purely random noise would have no signal.
+    env = GymnasiumAdapter("Pendulum-v1")
     for ep in range(5):
-        obs_seq = torch.randn(20, 3, 64, 64)
-        action_seq = torch.randn(20, cfg.d_action)
+        obs, _ = env.reset(seed=ep)
+        obs_list, action_list = [], []
+        for _ in range(20):
+            action = env.action_space.sample()
+            obs_list.append(torch.from_numpy(obs).float())
+            action_list.append(torch.from_numpy(action).float())
+            result = env.step(action)
+            obs = result.observation
+            if result.done:
+                break
+        obs_seq = torch.stack(obs_list)
+        action_seq = torch.stack(action_list)
 
         traj, cache = wm.run_with_cache(obs_seq, action_seq)
 
@@ -51,6 +67,7 @@ def main():
         labels = np.random.randint(0, 3, size=len(z_flat))
         all_labels.append(labels)
 
+    env.close()
     activations = torch.cat(all_activations, dim=0)
     labels = np.concatenate(all_labels)
 

--- a/examples/03_patching.py
+++ b/examples/03_patching.py
@@ -19,6 +19,7 @@ OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 from world_model_lens import HookContext, HookedWorldModel, HookPoint, WorldModelConfig
 from world_model_lens.backends.dreamerv3 import DreamerV3Adapter
+from world_model_lens.envs import GymnasiumAdapter
 from world_model_lens.patching.patcher import TemporalPatcher
 from world_model_lens.visualization import plot_patching_dashboard
 
@@ -28,14 +29,30 @@ def main():
     print("World Model Lens - Activation Patching Example")
     print("=" * 60)
 
-    cfg = WorldModelConfig(d_h=128, n_cat=16, n_cls=16, d_action=4, d_obs=12288)
+    # Pendulum-v1 gives a 3-dim vector obs and 1-dim continuous action — no extra gymnasium deps needed.
+    cfg = WorldModelConfig(d_h=128, n_cat=16, n_cls=16, d_action=1, d_obs=3)
     adapter = DreamerV3Adapter(cfg)
     wm = HookedWorldModel(adapter=adapter, config=cfg)
 
     print("\n[1] Creating clean and corrupted runs...")
 
-    obs_seq = torch.randn(15, 3, 64, 64)
-    action_seq = torch.randn(15, cfg.d_action)
+    # Collect a real 15-step trajectory so the clean run reflects genuine environment dynamics.
+    # The corruption applied below (obs_corrupted[5:]) stays as torch.randn — that perturbation
+    # is what the patching experiment is designed to measure, not part of the pipeline input.
+    env = GymnasiumAdapter("Pendulum-v1")
+    obs, _ = env.reset(seed=42)
+    obs_list, action_list = [], []
+    for _ in range(15):
+        action = env.action_space.sample()
+        obs_list.append(torch.from_numpy(obs).float())
+        action_list.append(torch.from_numpy(action).float())
+        result = env.step(action)
+        obs = result.observation
+        if result.done:
+            break
+    env.close()
+    obs_seq = torch.stack(obs_list)
+    action_seq = torch.stack(action_list)
 
     clean_traj, clean_cache = wm.run_with_cache(obs_seq, action_seq)
 

--- a/examples/03_patching.py
+++ b/examples/03_patching.py
@@ -54,12 +54,14 @@ def main():
     obs_seq = torch.stack(obs_list)
     action_seq = torch.stack(action_list)
 
-    clean_traj, clean_cache = wm.run_with_cache(obs_seq, action_seq)
+    clean_traj, clean_latent_traj, clean_cache = wm.run_with_cache(obs_seq, action_seq)
 
     obs_corrupted = obs_seq.clone()
     obs_corrupted[5:] = torch.randn_like(obs_corrupted[5:])
 
-    corrupted_traj, corrupted_cache = wm.run_with_cache(obs_corrupted, action_seq)
+    corrupted_traj, corrupted_latent_traj, corrupted_cache = wm.run_with_cache(
+        obs_corrupted, action_seq
+    )
 
     print(f"    Clean cache timesteps: {len(clean_cache.timesteps)}")
     print(f"    Corrupted cache timesteps: {len(corrupted_cache.timesteps)}")

--- a/examples/04_branching.py
+++ b/examples/04_branching.py
@@ -16,6 +16,7 @@ import matplotlib.pyplot as plt
 
 from world_model_lens import HookedWorldModel, WorldModelConfig
 from world_model_lens.backends.dreamerv3 import DreamerV3Adapter
+from world_model_lens.envs import GymnasiumAdapter
 from world_model_lens.visualization import plot_branching_dashboard
 
 OUTPUT_DIR = pathlib.Path("assets/examples")
@@ -27,14 +28,28 @@ def main():
     print("World Model Lens - Imagination Branching Example")
     print("=" * 60)
 
-    cfg = WorldModelConfig(d_h=128, n_cat=16, n_cls=16, d_action=4, d_obs=12288)
+    # Pendulum-v1 has a 3-dim obs and 1-dim continuous action matching these config values.
+    cfg = WorldModelConfig(d_h=128, n_cat=16, n_cls=16, d_action=1, d_obs=3)
     adapter = DreamerV3Adapter(cfg)
     wm = HookedWorldModel(adapter=adapter, config=cfg)
 
     print("\n[1] Collecting real trajectory...")
 
-    obs_seq = torch.randn(30, 3, 64, 64)
-    action_seq = torch.randn(30, cfg.d_action)
+    # Collect a real trajectory to fork from — branching off random noise has no interpretive value.
+    env = GymnasiumAdapter("Pendulum-v1")
+    obs, _ = env.reset(seed=42)
+    obs_list, action_list = [], []
+    for _ in range(30):
+        action = env.action_space.sample()
+        obs_list.append(torch.from_numpy(obs).float())
+        action_list.append(torch.from_numpy(action).float())
+        result = env.step(action)
+        obs = result.observation
+        if result.done:
+            break
+    env.close()
+    obs_seq = torch.stack(obs_list)
+    action_seq = torch.stack(action_list)
 
     real_traj, cache = wm.run_with_cache(obs_seq, action_seq)
     print(f"    Real trajectory: {real_traj.length} steps")

--- a/examples/04_branching.py
+++ b/examples/04_branching.py
@@ -51,7 +51,7 @@ def main():
     obs_seq = torch.stack(obs_list)
     action_seq = torch.stack(action_list)
 
-    real_traj, cache = wm.run_with_cache(obs_seq, action_seq)
+    real_world_traj, real_traj, cache = wm.run_with_cache(obs_seq, action_seq)
     print(f"    Real trajectory: {real_traj.length} steps")
 
     print("\n[2] Finding surprise peak for fork point...")
@@ -66,7 +66,7 @@ def main():
     branches = []
     for _ in range(5):
         actions = torch.randn(20, cfg.d_action)
-        imagined = wm.imagine(start_state=start_state, actions=actions, horizon=20)
+        _, imagined = wm.imagine(start_state=start_state, actions=actions, horizon=20)
         branches.append(imagined)
 
     print(f"    Created {len(branches)} branches")

--- a/examples/05_belief_analysis.py
+++ b/examples/05_belief_analysis.py
@@ -19,6 +19,7 @@ OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 from world_model_lens import HookedWorldModel, WorldModelConfig
 from world_model_lens.backends.dreamerv3 import DreamerV3Adapter
+from world_model_lens.envs import GymnasiumAdapter
 from world_model_lens.analysis.belief_analyzer import BeliefAnalyzer
 from world_model_lens.visualization import plot_belief_dashboard
 
@@ -28,7 +29,8 @@ def main():
     print("World Model Lens - Belief Analysis Example")
     print("=" * 60)
 
-    cfg = WorldModelConfig(d_h=128, n_cat=16, n_cls=16, d_action=4, d_obs=12288)
+    # Pendulum-v1 obs is (cos θ, sin θ, θ̇) — d_obs=3 and d_action=1 match its spaces exactly.
+    cfg = WorldModelConfig(d_h=128, n_cat=16, n_cls=16, d_action=1, d_obs=3)
     adapter = DreamerV3Adapter(cfg)
     wm = HookedWorldModel(adapter=adapter, config=cfg)
     analyzer = BeliefAnalyzer(wm)
@@ -38,8 +40,22 @@ def main():
 
     print("\n[1] Running forward pass...")
 
-    obs_seq = torch.randn(T, 3, 64, 64)
-    action_seq = torch.randn(T, cfg.d_action)
+    # Real observations let the belief analyzer detect genuine structure in the trajectory —
+    # surprise peaks and concept alignment are meaningless on i.i.d. Gaussian noise.
+    env = GymnasiumAdapter("Pendulum-v1")
+    obs, _ = env.reset(seed=42)
+    obs_list, action_list = [], []
+    for _ in range(T):
+        action = env.action_space.sample()
+        obs_list.append(torch.from_numpy(obs).float())
+        action_list.append(torch.from_numpy(action).float())
+        result = env.step(action)
+        obs = result.observation
+        if result.done:
+            break
+    env.close()
+    obs_seq = torch.stack(obs_list)
+    action_seq = torch.stack(action_list)
 
     traj, cache = wm.run_with_cache(obs_seq, action_seq)
 

--- a/examples/05_belief_analysis.py
+++ b/examples/05_belief_analysis.py
@@ -57,7 +57,7 @@ def main():
     obs_seq = torch.stack(obs_list)
     action_seq = torch.stack(action_list)
 
-    traj, cache = wm.run_with_cache(obs_seq, action_seq)
+    world_traj, traj, cache = wm.run_with_cache(obs_seq, action_seq)
 
     print("\n[2] Computing surprise timeline...")
 
@@ -96,7 +96,7 @@ def main():
 
     print("\n[5] Detecting hallucinations...")
 
-    imagined = wm.imagine(start_state=traj.states[0], horizon=20)
+    imagined_world, imagined = wm.imagine(start_state=traj.states[0], horizon=20)
 
     hallucination_result = analyzer.detect_hallucinations(
         real_traj=traj,

--- a/examples/06_disentanglement.py
+++ b/examples/06_disentanglement.py
@@ -52,7 +52,7 @@ def main():
     obs_seq = torch.stack(obs_list)
     action_seq = torch.stack(action_list)
 
-    traj, cache = wm.run_with_cache(obs_seq, action_seq)
+    world_traj, latent_traj, cache = wm.run_with_cache(obs_seq, action_seq)
 
     print("\n[2] Creating synthetic factors...")
 

--- a/examples/06_disentanglement.py
+++ b/examples/06_disentanglement.py
@@ -17,6 +17,7 @@ OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 from world_model_lens import HookedWorldModel, WorldModelConfig
 from world_model_lens.backends.dreamerv3 import DreamerV3Adapter
+from world_model_lens.envs import GymnasiumAdapter
 from world_model_lens.analysis.belief_analyzer import BeliefAnalyzer
 from world_model_lens.visualization import plot_disentanglement_dashboard
 
@@ -26,15 +27,30 @@ def main():
     print("World Model Lens - Disentanglement Analysis Example")
     print("=" * 60)
 
-    cfg = WorldModelConfig(d_h=128, n_cat=16, n_cls=16, d_action=4, d_obs=12288)
+    # Pendulum-v1 has a 3-dim obs and 1-dim continuous action matching these config values.
+    cfg = WorldModelConfig(d_h=128, n_cat=16, n_cls=16, d_action=1, d_obs=3)
     adapter = DreamerV3Adapter(cfg)
     wm = HookedWorldModel(adapter=adapter, config=cfg)
     analyzer = BeliefAnalyzer(wm)
 
     print("\n[1] Collecting activations...")
 
-    obs_seq = torch.randn(50, 3, 64, 64)
-    action_seq = torch.randn(50, cfg.d_action)
+    # Disentanglement metrics measure how well the latent space separates real factors of
+    # variation — running them on Gaussian noise produces scores with no interpretive meaning.
+    env = GymnasiumAdapter("Pendulum-v1")
+    obs, _ = env.reset(seed=42)
+    obs_list, action_list = [], []
+    for _ in range(50):
+        action = env.action_space.sample()
+        obs_list.append(torch.from_numpy(obs).float())
+        action_list.append(torch.from_numpy(action).float())
+        result = env.step(action)
+        obs = result.observation
+        if result.done:
+            break
+    env.close()
+    obs_seq = torch.stack(obs_list)
+    action_seq = torch.stack(action_list)
 
     traj, cache = wm.run_with_cache(obs_seq, action_seq)
 

--- a/examples/07_video_model.py
+++ b/examples/07_video_model.py
@@ -71,7 +71,7 @@ def main():
     frames = torch.stack(frame_list)
     print(f"\n[4] Collected {T} rendered frames from CartPole-v1: {frames.shape}")
 
-    traj, cache = wm.run_with_cache(frames)
+    traj, latent_traj, cache = wm.run_with_cache(frames)
     print(f"\n[5] Forward pass complete!")
     print(f"    Trajectory length: {traj.length}")
     print(f"    Cache keys: {cache.component_names}")

--- a/examples/07_video_model.py
+++ b/examples/07_video_model.py
@@ -11,12 +11,14 @@ A video prediction model:
 """
 
 import torch
+import torch.nn.functional as F
 import numpy as np
 
 from world_model_lens import HookedWorldModel
 #from world_model_lens.core.config import WorldModelConfig
 from world_model_lens.backends.generic_adapter import WorldModelConfig
 from world_model_lens.backends.video_adapter import VideoWorldModelAdapter
+from world_model_lens.envs import GymnasiumAdapter
 from world_model_lens.visualization import plot_video_model_dashboard
 import matplotlib.pyplot as plt
 import pathlib
@@ -54,8 +56,20 @@ def main():
     print("\n[3] Wrapped in HookedWorldModel")
 
     T = 10
-    frames = torch.randn(T, *frame_shape)
-    print(f"\n[4] Created video sequence: {frames.shape}")
+    # Render real CartPole frames — render_mode="rgb_array" returns (H, W, 3) uint8 numpy
+    # arrays that we convert to (3, 64, 64) float tensors via channel-first transpose and resize.
+    env = GymnasiumAdapter("CartPole-v1", render_mode="rgb_array")
+    env.reset(seed=42)
+    frame_list = []
+    for _ in range(T):
+        raw = env.render()
+        frame_t = torch.from_numpy(raw).permute(2, 0, 1).float() / 255.0
+        frame_t = F.interpolate(frame_t.unsqueeze(0), size=(64, 64), mode="bilinear", align_corners=False).squeeze(0)
+        frame_list.append(frame_t)
+        env.step(env.action_space.sample())
+    env.close()
+    frames = torch.stack(frame_list)
+    print(f"\n[4] Collected {T} rendered frames from CartPole-v1: {frames.shape}")
 
     traj, cache = wm.run_with_cache(frames)
     print(f"\n[5] Forward pass complete!")

--- a/examples/08_toy_video_world_model.py
+++ b/examples/08_toy_video_world_model.py
@@ -89,7 +89,7 @@ def main():
     print(f"    Video shape: {frames.shape}")
 
     print("\n[3] Running forward pass with caching...")
-    traj, cache = wm.run_with_cache(frames)
+    traj, latent_traj, cache = wm.run_with_cache(frames)
     print(f"    Trajectory states: {len(traj.states)}")
     print(f"    Cache keys: {list(cache.keys())[:5]}...")
 
@@ -135,7 +135,7 @@ def main():
 
     print("\n[7] Testing imagination (no actions needed)...")
     start_state = traj.states[0]
-    imagined = wm.imagine(start_state, actions=None, horizon=10)
+    imagined, imagined_latent = wm.imagine(start_state, actions=None, horizon=10)
     print(f"    Imagined states: {len(imagined.states)}")
 
     print("\n[8] Testing RL-specific analysis (should be skipped)...")

--- a/examples/09_toy_scientific_dynamics.py
+++ b/examples/09_toy_scientific_dynamics.py
@@ -77,7 +77,7 @@ def main():
     print(f"    Z range: [{lorenz_traj[:, 2].min():.2f}, {lorenz_traj[:, 2].max():.2f}]")
 
     print("\n[3] Running forward pass with Lorenz trajectory...")
-    traj, cache = wm.run_with_cache(lorenz_traj)
+    traj, latent_traj, cache = wm.run_with_cache(lorenz_traj)
     print(f"    Trajectory states: {len(traj.states)}")
     print(f"    Cache keys: {list(cache.keys())[:5]}...")
 
@@ -133,7 +133,7 @@ def main():
 
     print("\n[7] Testing imagination (no actions needed)...")
     start_state = traj.states[0]
-    imagined = wm.imagine(start_state, actions=None, horizon=20)
+    imagined, imagined_latent = wm.imagine(start_state, actions=None, horizon=20)
     print(f"    Imagined states: {len(imagined.states)}")
 
     print("\n[8] Testing RL-specific analysis (should be skipped)...")
@@ -147,7 +147,7 @@ def main():
     pendulum_traj = generate_pendulum_trajectory(n_steps=100)
     # Pad pendulum trajectory to match model input dimension (3)
     pendulum_traj = torch.cat([pendulum_traj, torch.zeros(pendulum_traj.shape[0], 1)], dim=1)
-    traj2, cache2 = wm.run_with_cache(pendulum_traj)
+    traj2, latent_traj2, cache2 = wm.run_with_cache(pendulum_traj)
 
     surprise2 = belief_analyzer.surprise_timeline(cache2)
     print(f"    Pendulum mean surprise: {surprise2.mean_surprise:.4f}")

--- a/examples/10_causal_engine.py
+++ b/examples/10_causal_engine.py
@@ -56,7 +56,7 @@ def main():
     engine = CounterfactualEngine(wm)
 
     # --- Baseline trajectory (no hooks)
-    baseline_traj, cache = wm.run_with_cache(obs_seq, action_seq)
+    baseline_traj, baseline_latent_traj, cache = wm.run_with_cache(obs_seq, action_seq)
     print(f"\nBaseline trajectory: {len(baseline_traj.states)} states")
     print(f"  State dim: {baseline_traj.states[0].state.shape}")
 

--- a/examples/10_causal_engine.py
+++ b/examples/10_causal_engine.py
@@ -18,6 +18,7 @@ from world_model_lens.causal import (
     Intervention,
     rollout_comparison,
 )
+from world_model_lens.envs import GymnasiumAdapter
 from world_model_lens.visualization import plot_causal_engine_dashboard
 
 OUTPUT_DIR = pathlib.Path("assets/examples")
@@ -29,13 +30,28 @@ def main():
     print("World Model Lens — CounterfactualEngine walkthrough")
     print("=" * 60)
 
-    cfg = WorldModelConfig(d_h=128, n_cat=16, n_cls=16, d_action=4, d_obs=12288)
+    # Pendulum-v1 has a 3-dim obs and 1-dim continuous action matching these config values.
+    cfg = WorldModelConfig(d_h=128, n_cat=16, n_cls=16, d_action=1, d_obs=3)
     adapter = DreamerV3Adapter(cfg)
     wm = HookedWorldModel(adapter=adapter, config=cfg)
 
     T = 15
-    obs_seq = torch.randn(T, 3, 64, 64)
-    action_seq = torch.randn(T, cfg.d_action)
+    # Counterfactual interventions operate on latent states, so the baseline trajectory
+    # must come from a real environment to give those interventions causal meaning.
+    env = GymnasiumAdapter("Pendulum-v1")
+    obs, _ = env.reset(seed=42)
+    obs_list, action_list = [], []
+    for _ in range(T):
+        action = env.action_space.sample()
+        obs_list.append(torch.from_numpy(obs).float())
+        action_list.append(torch.from_numpy(action).float())
+        result = env.step(action)
+        obs = result.observation
+        if result.done:
+            break
+    env.close()
+    obs_seq = torch.stack(obs_list)
+    action_seq = torch.stack(action_list)
 
     engine = CounterfactualEngine(wm)
 

--- a/examples/11_hub_iris_demo.py
+++ b/examples/11_hub_iris_demo.py
@@ -41,7 +41,7 @@ def main():
 
     # 3. Forward Pass (Real)
     print(f"\n[2/4] Running forward pass on {T} real observations...")
-    traj, cache = wm.run_with_cache(obs[:, 0])  # HookedWorldModel expects [T, ...]
+    traj, latent_traj, cache = wm.run_with_cache(obs[:, 0])  # HookedWorldModel expects [T, ...]
 
     print(f"[OK] Forward pass complete. Trajectory length: {len(traj.states)}")
 
@@ -53,7 +53,7 @@ def main():
     # 4. Imagination Rollout
     print("\n[3/4] Running 10-step imagination rollout from last real state...")
     start_state = traj.states[-1]
-    imagined = wm.imagine(start_state, horizon=10)
+    imagined, imagined_latent = wm.imagine(start_state, horizon=10)
 
     print(f"[OK] Imagination complete. Rollout length: {len(imagined.states)}")
 

--- a/examples/11_unified_disentanglement.py
+++ b/examples/11_unified_disentanglement.py
@@ -16,6 +16,7 @@ OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 from world_model_lens import HookedWorldModel, WorldModelConfig
 from world_model_lens.backends.dreamerv3 import DreamerV3Adapter
+from world_model_lens.envs import GymnasiumAdapter
 from world_model_lens.analysis.metrics import DisentanglementEvaluationSuite
 
 
@@ -26,15 +27,30 @@ def main():
 
     # For demonstration, we'll use DreamerV3 (which has similar components)
     # In a real IJEPA setup, you'd use the IJEPA backend
-    cfg = WorldModelConfig(d_h=128, n_cat=16, n_cls=16, d_action=4, d_obs=12288)
+    # Pendulum-v1 has a 3-dim obs and 1-dim continuous action matching these config values.
+    cfg = WorldModelConfig(d_h=128, n_cat=16, n_cls=16, d_action=1, d_obs=3)
     adapter = DreamerV3Adapter(cfg)
     wm = HookedWorldModel(adapter=adapter, config=cfg)
     analyzer = DisentanglementEvaluationSuite()
 
     print("\n[1] Collecting activations from model run...")
 
-    obs_seq = torch.randn(50, 3, 64, 64)
-    action_seq = torch.randn(50, cfg.d_action)
+    # Real environment observations give the latent space genuine structure to disentangle —
+    # metrics computed on Gaussian noise are numerically arbitrary.
+    env = GymnasiumAdapter("Pendulum-v1")
+    obs, _ = env.reset(seed=42)
+    obs_list, action_list = [], []
+    for _ in range(50):
+        action = env.action_space.sample()
+        obs_list.append(torch.from_numpy(obs).float())
+        action_list.append(torch.from_numpy(action).float())
+        result = env.step(action)
+        obs = result.observation
+        if result.done:
+            break
+    env.close()
+    obs_seq = torch.stack(obs_list)
+    action_seq = torch.stack(action_list)
 
     traj, cache = wm.run_with_cache(obs_seq, action_seq)
 

--- a/examples/11_unified_disentanglement.py
+++ b/examples/11_unified_disentanglement.py
@@ -52,7 +52,7 @@ def main():
     obs_seq = torch.stack(obs_list)
     action_seq = torch.stack(action_list)
 
-    traj, cache = wm.run_with_cache(obs_seq, action_seq)
+    world_traj, traj, cache = wm.run_with_cache(obs_seq, action_seq)
 
     print("\n[2] Creating synthetic ground truth factors...")
 

--- a/examples/12_aopc_example.py
+++ b/examples/12_aopc_example.py
@@ -17,6 +17,7 @@ import matplotlib.pyplot as plt
 
 from world_model_lens import HookedWorldModel, WorldModelConfig
 from world_model_lens.backends.dreamerv3 import DreamerV3Adapter
+from world_model_lens.envs import GymnasiumAdapter
 from world_model_lens.analysis import FaithfulnessAnalyzer
 
 OUTPUT_DIR = pathlib.Path("assets/examples")
@@ -29,16 +30,29 @@ def main():
     print("=" * 60)
 
     # Setup world model
-    cfg = WorldModelConfig(d_h=256, n_cat=32, n_cls=32, d_action=4, d_obs=12288)
+    # Pendulum-v1 has a 3-dim obs and 1-dim continuous action matching these config values.
+    cfg = WorldModelConfig(d_h=256, n_cat=32, n_cls=32, d_action=1, d_obs=3)
     adapter = DreamerV3Adapter(cfg)
     wm = HookedWorldModel(adapter=adapter, config=cfg, name="aopc_example")
 
-    # Generate data
-    T, C, H, W = 20, 3, 64, 64
-    obs_seq = torch.randn(T, C, H, W)
-    action_seq = torch.randn(T, cfg.d_action)
-
-    print(f"Created data: obs={obs_seq.shape}, actions={action_seq.shape}")
+    # AOPC measures faithfulness of latent representations — perturbation curves computed on
+    # random noise have no ground truth to be faithful to.
+    T = 20
+    env = GymnasiumAdapter("Pendulum-v1")
+    obs, _ = env.reset(seed=42)
+    obs_list, action_list = [], []
+    for _ in range(T):
+        action = env.action_space.sample()
+        obs_list.append(torch.from_numpy(obs).float())
+        action_list.append(torch.from_numpy(action).float())
+        result = env.step(action)
+        obs = result.observation
+        if result.done:
+            break
+    env.close()
+    obs_seq = torch.stack(obs_list)
+    action_seq = torch.stack(action_list)
+    print(f"Collected {len(obs_list)} steps from Pendulum-v1: obs={obs_seq.shape}, actions={action_seq.shape}")
 
     # Initialize analyzer
     analyzer = FaithfulnessAnalyzer(wm)

--- a/tests/backends/test_ijepa_adapter.py
+++ b/tests/backends/test_ijepa_adapter.py
@@ -112,7 +112,7 @@ def test_ijepa_hooked_integration():
     wm = HookedWorldModel(adapter=adapter, config=config)
     
     obs = torch.randn(1, 3, 224, 224)
-    traj, cache = wm.run_with_cache(obs)
+    _, _, cache = wm.run_with_cache(obs)
     
     # Verify target encoding appeared in cache (if implemented in HookedWorldModel)
     if "target_encoding" in cache.component_names:

--- a/tests/backends/test_ijepa_integration.py
+++ b/tests/backends/test_ijepa_integration.py
@@ -29,7 +29,7 @@ def test_ijepa_final_integration():
         
         # 4. Test run_with_cache including target_encoding
         obs = torch.randn(2, 3, 224, 224)
-        traj, cache = wm.run_with_cache(obs)
+        _, _, cache = wm.run_with_cache(obs)
         
         # Verify cache points
         assert "target_encoding" in cache.component_names

--- a/tests/test_belief_analyzer.py
+++ b/tests/test_belief_analyzer.py
@@ -64,7 +64,7 @@ class TestBeliefAnalyzer:
 
         # Run with cache
         with torch.no_grad():
-            _, cache = wm.run_with_cache(obs)
+            _, _, cache = wm.run_with_cache(obs)
 
         result = analyzer.surprise_timeline(cache)
 

--- a/tests/test_faithfulness_analyzer.py
+++ b/tests/test_faithfulness_analyzer.py
@@ -249,7 +249,7 @@ class TestFaithfulnessAnalyzer:
         def predictor_fn(cache):
             return cache["reconstruction"]
 
-        _, cache = video_wm.run_with_cache(obs)
+        _, _, cache = video_wm.run_with_cache(obs)
         z = cache["z_posterior"]
         num_dims = z.shape[-1] if z is not None else 16
 
@@ -299,7 +299,7 @@ class TestAOPCIntegration:
 
         analyzer = FaithfulnessAnalyzer(wm)
 
-        _, cache = wm.run_with_cache(obs)
+        _, _, cache = wm.run_with_cache(obs)
 
         result = analyzer.aopc(obs, target_component="h", max_k=3)
         assert isinstance(result, AOPCResult)

--- a/tests/test_hooked_world_model.py
+++ b/tests/test_hooked_world_model.py
@@ -5,20 +5,26 @@ import torch
 import torch.nn as nn
 
 from world_model_lens import HookedWorldModel, WorldModelConfig
+from world_model_lens.core.activation_cache import ActivationCache
+from world_model_lens.core.world_trajectory import WorldTrajectory
 from world_model_lens.core.latent_trajectory import LatentTrajectory
 from world_model_lens.backends.base_adapter import BaseModelAdapter, WorldModelCapabilities
 
 
 def test_run_with_cache_returns_correct_length(hooked_wm, fake_obs_seq, fake_action_seq):
     """Test run_with_cache returns trajectory of correct length."""
-    traj, cache = hooked_wm.run_with_cache(fake_obs_seq, fake_action_seq)
-    assert traj.length == 10
+    world_traj, latent_traj, cache = hooked_wm.run_with_cache(fake_obs_seq, fake_action_seq)
+    assert isinstance(world_traj, WorldTrajectory)
+    assert isinstance(latent_traj, LatentTrajectory)
+    assert isinstance(cache, ActivationCache)
+    assert world_traj.length == 10
+    assert latent_traj.length == 10
     assert len(cache.timesteps) == 10
 
 
 def test_run_with_cache_caches_all_components(hooked_wm, fake_obs_seq, fake_action_seq):
     """Test cache contains all expected components."""
-    traj, cache = hooked_wm.run_with_cache(fake_obs_seq, fake_action_seq)
+    _, _, cache = hooked_wm.run_with_cache(fake_obs_seq, fake_action_seq)
     assert "state" in cache.component_names
     assert "z_posterior" in cache.component_names
     assert "z_prior" in cache.component_names
@@ -28,8 +34,9 @@ def test_imagine_returns_correct_horizon(hooked_wm, fake_trajectory):
     """Test imagine returns correct horizon length."""
     start_state = fake_trajectory.states[0]
     horizon = 20
-    imagined = hooked_wm.imagine(start_state=start_state, horizon=horizon)
-    assert imagined.length == horizon
+    imagined_world, imagined_latent = hooked_wm.imagine(start_state=start_state, horizon=horizon)
+    assert imagined_world.length == horizon
+    assert imagined_latent.length == horizon
 
 
 def test_named_weights_accessible(hooked_wm):
@@ -219,7 +226,7 @@ def test_run_with_cache_falls_back_to_predict_value_for_legacy_adapter():
 
     observations = torch.randn(3, cfg.d_obs)
     actions = torch.randn(3, cfg.d_action)
-    _, cache = wm.run_with_cache(observations, actions)
+    _, _, cache = wm.run_with_cache(observations, actions)
 
     assert len(adapter.value_calls) == 3
     assert "value" in cache.component_names
@@ -227,9 +234,9 @@ def test_run_with_cache_falls_back_to_predict_value_for_legacy_adapter():
 
 def test_run_with_cache_tracks_action_sources(hooked_wm, fake_obs_seq, fake_action_seq):
     """Test that run_with_cache properly tracks action sources."""
-    traj, _ = hooked_wm.run_with_cache(fake_obs_seq, fake_action_seq)
+    world_traj, _, _ = hooked_wm.run_with_cache(fake_obs_seq, fake_action_seq)
 
-    for state in traj.states:
+    for state in world_traj.states:
         if state.has_action():
             assert state.action_source is not None
             assert state.action_source.source_type == "externally_provided"
@@ -238,8 +245,8 @@ def test_run_with_cache_tracks_action_sources(hooked_wm, fake_obs_seq, fake_acti
 
 def test_non_jepa_run_with_cache_does_not_use_forward_runner_metadata(hooked_wm, fake_obs_seq, fake_action_seq):
     """Non-JEPA models should remain on the stable wrapper execution path."""
-    traj, _ = hooked_wm.run_with_cache(fake_obs_seq, fake_action_seq)
-    assert traj.metadata.get("forward_runner") is None
+    world_traj, _, _ = hooked_wm.run_with_cache(fake_obs_seq, fake_action_seq)
+    assert world_traj.metadata.get("forward_runner") is None
 
 def test_latent_traj_to_world_traj_raises_on_missing_h_t(hooked_wm):
     """Invalid runner output should fail loudly instead of fabricating zero states."""
@@ -308,16 +315,15 @@ def test_imagine_samples_actions_from_policy():
     start_ws = WorldState(state=start_state, timestep=0)
 
     # Imagine without providing actions - should sample from policy
-    imagined = wm.imagine(start_state=start_ws, horizon=5)
+    imagined_world, _ = wm.imagine(start_state=start_ws, horizon=5)
 
     # Check that actions were sampled
-    for i, state in enumerate(imagined.states):
-        if i > 0:  # Skip the first state which is the start state
-            assert state.has_action()
-            assert state.action_source is not None
-            assert state.action_source.source_type == "policy_sampled"
-            assert state.action_source.policy_logits is not None
-            assert state.action_source.temperature == 1.0
+    for state in imagined_world.states:
+        assert state.has_action()
+        assert state.action_source is not None
+        assert state.action_source.source_type == "policy_sampled"
+        assert state.action_source.policy_logits is not None
+        assert state.action_source.temperature == 1.0
 
 
 def test_imagine_uses_provided_actions():
@@ -368,10 +374,10 @@ def test_imagine_uses_provided_actions():
 
     # Provide actions explicitly
     actions = torch.randn(3, cfg.d_action)
-    imagined = wm.imagine(start_state=start_ws, actions=actions, horizon=3)
+    imagined_world, _ = wm.imagine(start_state=start_ws, actions=actions, horizon=3)
 
     # Check that provided actions were used
-    for i, state in enumerate(imagined.states):
+    for i, state in enumerate(imagined_world.states):
         assert state.has_action()
         assert state.action_source is not None
         assert state.action_source.source_type == "externally_provided"
@@ -441,7 +447,7 @@ def test_transition_hook_applies():
 
     observations = torch.randn(2, cfg.d_obs)
     actions = torch.randn(2, cfg.d_action)
-    traj, _ = wm.run_with_cache(observations, actions)
+    _, _, _ = wm.run_with_cache(observations, actions)
 
     # Should have called the hook for each timestep
     assert len(hook_calls) == 2

--- a/tests/test_ijepa_features.py
+++ b/tests/test_ijepa_features.py
@@ -97,9 +97,10 @@ def test_hooked_world_model_routes_jepa_through_forward_runner():
     wm = HookedWorldModel(adapter=adapter, config=config)
 
     obs = torch.randn(1, 3, 224, 224)
-    traj, cache = wm.run_with_cache(obs)
+    traj, latent_traj, cache = wm.run_with_cache(obs)
 
     assert len(traj.states) > 0
+    assert len(latent_traj.states) > 0
     assert traj.metadata["forward_runner"] is True
     assert traj.metadata["world_model_family"] == WorldModelFamily.JEPA.name
 

--- a/tests/test_integration_non_rl.py
+++ b/tests/test_integration_non_rl.py
@@ -191,21 +191,23 @@ class TestHookedWorldModelWithVideo:
         """Test run_with_cache with video sequence."""
         frames = torch.randn(10, 3, 64, 64)
 
-        traj, cache = video_wm.run_with_cache(frames)
+        world_traj, latent_traj, cache = video_wm.run_with_cache(frames)
 
-        assert traj is not None
+        assert world_traj is not None
+        assert latent_traj is not None
         assert cache is not None
-        assert len(traj.states) == 10
+        assert len(world_traj.states) == 10
+        assert len(latent_traj.states) == 10
 
     def test_run_with_cache_no_actions(self, video_wm):
         """Test that run_with_cache works without actions."""
         frames = torch.randn(10, 3, 64, 64)
         actions = None
 
-        traj, cache = video_wm.run_with_cache(frames, actions=actions)
+        world_traj, _, cache = video_wm.run_with_cache(frames, actions=actions)
 
-        assert traj is not None
-        for state in traj.states:
+        assert world_traj is not None
+        for state in world_traj.states:
             assert state.action is None
 
 
@@ -239,11 +241,13 @@ class TestHookedWorldModelWithScientific:
         """Test run_with_cache with observation sequence."""
         observations = torch.randn(50, 10)
 
-        traj, cache = scientific_wm.run_with_cache(observations)
+        world_traj, latent_traj, cache = scientific_wm.run_with_cache(observations)
 
-        assert traj is not None
+        assert world_traj is not None
+        assert latent_traj is not None
         assert cache is not None
-        assert len(traj.states) == 50
+        assert len(world_traj.states) == 50
+        assert len(latent_traj.states) == 50
 
 
 class TestBeliefAnalyzerWithNonRL:
@@ -266,7 +270,7 @@ class TestBeliefAnalyzerWithNonRL:
     def test_surprise_timeline_video(self, video_wm):
         """Test surprise timeline with video model."""
         frames = torch.randn(20, 3, 64, 64)
-        traj, cache = video_wm.run_with_cache(frames)
+        _, _, cache = video_wm.run_with_cache(frames)
 
         analyzer = BeliefAnalyzer(video_wm)
         result = analyzer.surprise_timeline(cache)
@@ -278,7 +282,7 @@ class TestBeliefAnalyzerWithNonRL:
     def test_surprise_timeline_scientific(self, scientific_wm):
         """Test surprise timeline with scientific model."""
         observations = torch.randn(30, 10)
-        traj, cache = scientific_wm.run_with_cache(observations)
+        _, _, cache = scientific_wm.run_with_cache(observations)
 
         analyzer = BeliefAnalyzer(scientific_wm)
         result = analyzer.surprise_timeline(cache)
@@ -288,17 +292,17 @@ class TestBeliefAnalyzerWithNonRL:
     def test_reward_attribution_returns_unavailable(self, scientific_wm):
         """Test that reward attribution returns unavailable for non-RL models."""
         observations = torch.randn(20, 10)
-        traj, cache = scientific_wm.run_with_cache(observations)
+        world_traj, _, cache = scientific_wm.run_with_cache(observations)
 
         analyzer = BeliefAnalyzer(scientific_wm)
-        result = analyzer.reward_attribution(traj, cache)
+        result = analyzer.reward_attribution(world_traj, cache)
 
         assert result.is_available is False
 
     def test_value_analysis_returns_unavailable(self, scientific_wm):
         """Test that value analysis returns unavailable for non-RL models."""
         observations = torch.randn(20, 10)
-        traj, cache = scientific_wm.run_with_cache(observations)
+        _, _, cache = scientific_wm.run_with_cache(observations)
 
         analyzer = BeliefAnalyzer(scientific_wm)
         result = analyzer.value_analysis(cache)
@@ -319,7 +323,7 @@ class TestGeometryAnalyzerWithNonRL:
     def test_pca_projection(self, scientific_wm):
         """Test PCA projection with scientific model."""
         observations = torch.randn(30, 10)
-        traj, cache = scientific_wm.run_with_cache(observations)
+        _, _, cache = scientific_wm.run_with_cache(observations)
 
         analyzer = GeometryAnalyzer(scientific_wm)
         result = analyzer.pca_projection(cache)
@@ -330,7 +334,7 @@ class TestGeometryAnalyzerWithNonRL:
     def test_trajectory_metrics(self, scientific_wm):
         """Test trajectory metrics with scientific model."""
         observations = torch.randn(30, 10)
-        traj, cache = scientific_wm.run_with_cache(observations)
+        _, _, cache = scientific_wm.run_with_cache(observations)
 
         analyzer = GeometryAnalyzer(scientific_wm)
         result = analyzer.trajectory_metrics(cache)
@@ -342,7 +346,7 @@ class TestGeometryAnalyzerWithNonRL:
     def test_clustering(self, scientific_wm):
         """Test clustering with scientific model."""
         observations = torch.randn(30, 10)
-        traj, cache = scientific_wm.run_with_cache(observations)
+        _, _, cache = scientific_wm.run_with_cache(observations)
 
         analyzer = GeometryAnalyzer(scientific_wm)
         result = analyzer.clustering(cache, n_clusters=5)
@@ -354,7 +358,7 @@ class TestGeometryAnalyzerWithNonRL:
     def test_manifold_analysis(self, scientific_wm):
         """Test manifold analysis with scientific model."""
         observations = torch.randn(30, 10)
-        traj, cache = scientific_wm.run_with_cache(observations)
+        _, _, cache = scientific_wm.run_with_cache(observations)
 
         analyzer = GeometryAnalyzer(scientific_wm)
         result = analyzer.manifold_analysis(cache)
@@ -377,7 +381,7 @@ class TestTemporalMemoryProberWithNonRL:
     def test_memory_retention(self, scientific_wm):
         """Test memory retention analysis."""
         observations = torch.randn(50, 10)
-        traj, cache = scientific_wm.run_with_cache(observations)
+        _, _, cache = scientific_wm.run_with_cache(observations)
 
         prober = TemporalMemoryProber(scientific_wm)
         result = prober.memory_retention(cache)
@@ -389,7 +393,7 @@ class TestTemporalMemoryProberWithNonRL:
     def test_temporal_dependencies(self, scientific_wm):
         """Test temporal dependency analysis."""
         observations = torch.randn(30, 10)
-        traj, cache = scientific_wm.run_with_cache(observations)
+        _, _, cache = scientific_wm.run_with_cache(observations)
 
         prober = TemporalMemoryProber(scientific_wm)
         result = prober.temporal_dependencies(cache)
@@ -400,7 +404,7 @@ class TestTemporalMemoryProberWithNonRL:
     def test_sequential_patterns(self, scientific_wm):
         """Test sequential pattern detection."""
         observations = torch.randn(30, 10)
-        traj, cache = scientific_wm.run_with_cache(observations)
+        _, _, cache = scientific_wm.run_with_cache(observations)
 
         prober = TemporalMemoryProber(scientific_wm)
         result = prober.sequential_patterns(cache)
@@ -435,7 +439,7 @@ class TestScientificTrajectoryGenerators:
         traj = generate_lorenz_trajectory(n_steps=50)
         observations = traj
 
-        result_traj, cache = wm.run_with_cache(observations)
+        result_traj, _, cache = wm.run_with_cache(observations)
 
         assert result_traj is not None
         assert len(result_traj.states) == 50
@@ -454,15 +458,17 @@ class TestImaginationWithNonRL:
     def test_imagine_without_actions(self, scientific_wm):
         """Test imagination without actions (non-RL model)."""
         observations = torch.randn(10, 10)
-        traj, cache = scientific_wm.run_with_cache(observations)
+        world_traj, latent_traj, cache = scientific_wm.run_with_cache(observations)
 
-        start_state = traj.states[0]
-        imagined = scientific_wm.imagine(start_state, actions=None, horizon=20)
+        start_state = latent_traj.states[0]
+        imagined_world, imagined_latent = scientific_wm.imagine(start_state, actions=None, horizon=20)
 
-        assert imagined is not None
-        assert len(imagined.states) == 20
+        assert imagined_world is not None
+        assert imagined_latent is not None
+        assert len(imagined_world.states) == 20
+        assert len(imagined_latent.states) == 20
 
-        for state in imagined.states:
+        for state in imagined_world.states:
             assert state.action is None
 
 

--- a/tests/test_kv_cache_hooks.py
+++ b/tests/test_kv_cache_hooks.py
@@ -64,7 +64,7 @@ def test_kv_hook_creates_entries():
     hook = HookPoint(name="kv_cache", fn=create_kv, timestep=1)
     wm.add_hook(hook)
 
-    traj, cache = wm.run_with_cache(obs)
+    _, _, cache = wm.run_with_cache(obs)
 
     assert torch.equal(cache.get_kv(0, "k", 1), torch.tensor([1.0, 1.0]))
     assert torch.equal(cache.get_kv(0, "v", 1), torch.tensor([1.5, 1.5]))
@@ -86,7 +86,7 @@ def test_kv_hook_modifies_past_entry():
     wm.add_hook(HookPoint(name="kv_cache", fn=create_kv, timestep=1))
     wm.add_hook(HookPoint(name="kv_cache", fn=modify_prev, timestep=2))
 
-    traj, cache = wm.run_with_cache(obs)
+    _, _, cache = wm.run_with_cache(obs)
 
     # created at t=1 then modified at t=2
     assert torch.equal(cache.get_kv(0, "k", 1), torch.tensor([10.0, 10.0]))
@@ -105,7 +105,7 @@ def test_kv_hook_removes_entry():
     wm.add_hook(HookPoint(name="kv_cache", fn=create_kv, timestep=1))
     wm.add_hook(HookPoint(name="kv_cache", fn=delete_prev, timestep=2))
 
-    traj, cache = wm.run_with_cache(obs)
+    _, _, cache = wm.run_with_cache(obs)
 
     # entry at t=1 should have been deleted by hook at t=2
     assert cache.get_kv(0, "k", 1, None) is None
@@ -124,7 +124,7 @@ def test_kv_hook_time_slice_applies_across_range():
     # time_slice from 1 (inclusive) to 4 (exclusive) should fire at 1,2,3
     wm.add_hook(HookPoint(name="kv_cache", fn=slice_hook, time_slice=[1, 4]))
 
-    traj, cache = wm.run_with_cache(obs)
+    _, _, cache = wm.run_with_cache(obs)
 
     assert calls == [1, 2, 3]
     for t in calls:

--- a/tests/test_run_with_hooks_integration.py
+++ b/tests/test_run_with_hooks_integration.py
@@ -15,7 +15,9 @@ def test_temp_hooks_are_cleaned_up(hooked_wm, fake_obs_seq, fake_action_seq):
     hp = HookPoint(name="z_posterior", fn=patch_z, timestep=2)
 
     # run with hook and request cache
-    traj, cache = hooked_wm.run_with_hooks(fake_obs_seq, fake_action_seq, [hp], return_cache=True)
+    world_traj, latent_traj, cache = hooked_wm.run_with_hooks(
+        fake_obs_seq, fake_action_seq, [hp], return_cache=True
+    )
 
     # Hook should have been called at t=2
     assert (2, "z_posterior") in calls
@@ -23,7 +25,9 @@ def test_temp_hooks_are_cleaned_up(hooked_wm, fake_obs_seq, fake_action_seq):
     # After run_with_hooks returns the registry should not retain the hook
     # Registering the same HookPoint again should result in one call only
     calls.clear()
-    traj2, cache2 = hooked_wm.run_with_hooks(fake_obs_seq, fake_action_seq, [hp], return_cache=True)
+    world_traj2, latent_traj2, cache2 = hooked_wm.run_with_hooks(
+        fake_obs_seq, fake_action_seq, [hp], return_cache=True
+    )
     assert calls.count((2, "z_posterior")) == 1
 
 

--- a/world_model_lens/advanced/interpretability.py
+++ b/world_model_lens/advanced/interpretability.py
@@ -19,7 +19,7 @@ import torch.nn.functional as functional
 
 if TYPE_CHECKING:
     from world_model_lens import HookedWorldModel
-    from world_model_lens.core import ActivationCache, WorldTrajectory
+    from world_model_lens.core import ActivationCache, LatentTrajectory
     from world_model_lens.probing.prober import ProbeResult
     from world_model_lens.sae.sae import SparseAutoencoder as Sae
 
@@ -206,7 +206,7 @@ class PathPatcher:
 
         try:
             obs = torch.randn(10, self.wm.config.d_obs)
-            traj, _ = self.wm.run_with_cache(obs)
+            _, traj, _ = self.wm.run_with_cache(obs)
             patched_metric = metric_fn(traj)
         except Exception:
             patched_metric = 0.0
@@ -383,7 +383,7 @@ class LongHorizonAnalyzer:
 
     def detect_planning_horizon(
         self,
-        trajectory: WorldTrajectory,
+        trajectory: LatentTrajectory,
         horizon: int = 100,
     ) -> int:
         """Detect timesteps where future predictions lose fidelity.
@@ -401,7 +401,7 @@ class LongHorizonAnalyzer:
         if actions is None or actions.shape[0] < horizon:
             horizon = actions.shape[0] if actions is not None else 10
 
-        imagined = self.wm.imagine(start_state, actions[:horizon], horizon=horizon)
+        _, imagined = self.wm.imagine(start_state, actions[:horizon], horizon=horizon)
 
         real_rewards = trajectory.rewards_real
         pred_rewards = imagined.rewards_pred if imagined.rewards_pred is not None else None
@@ -421,8 +421,8 @@ class LongHorizonAnalyzer:
 
     def compute_belief_drift(
         self,
-        imagined_trajectory: WorldTrajectory,
-        real_trajectory: WorldTrajectory | None = None,
+        imagined_trajectory: LatentTrajectory,
+        real_trajectory: LatentTrajectory | None = None,
     ) -> torch.Tensor:
         """Compute KL divergence accumulating over imagination.
 
@@ -453,7 +453,7 @@ class LongHorizonAnalyzer:
 
     def detect_overcommitment(
         self,
-        trajectory: WorldTrajectory,
+        trajectory: LatentTrajectory,
         threshold: float = 0.1,
     ) -> list[int]:
         """Detect timesteps where value predictions don't update after surprise.
@@ -465,7 +465,9 @@ class LongHorizonAnalyzer:
         Returns:
             List of overcommitted timesteps.
         """
-        value_pred = trajectory.value_pred_sequence
+        value_pred = torch.stack(
+            [state.value_pred for state in trajectory.states if state.value_pred is not None], dim=0
+        ) if any(state.value_pred is not None for state in trajectory.states) else None
         surprise = trajectory.kl_sequence
 
         if value_pred is None or surprise is None:
@@ -482,14 +484,14 @@ class LongHorizonAnalyzer:
 
     def full_analysis(
         self,
-        trajectory: WorldTrajectory,
+        trajectory: LatentTrajectory,
         horizon: int = 50,
     ) -> dict[str, Any]:
         """Run complete long-horizon analysis."""
         start_state = trajectory.states[0]
         actions = trajectory.actions
 
-        imagined = self.wm.imagine(start_state, actions, horizon=horizon)
+        _, imagined = self.wm.imagine(start_state, actions, horizon=horizon)
 
         planning_horizon = self.detect_planning_horizon(trajectory, horizon)
         belief_drift = self.compute_belief_drift(imagined, trajectory)

--- a/world_model_lens/analysis/continual_learning.py
+++ b/world_model_lens/analysis/continual_learning.py
@@ -138,7 +138,7 @@ class ContinualLearningAuditor:
         self.wm.adapter.load_state_dict(state_dict)
 
         # Run forward pass
-        trajectory, cache = self.wm.run_with_cache(observations, actions)
+        trajectory, _, cache = self.wm.run_with_cache(observations, actions)
 
         # Cache for later comparison
         self._cache_store[epoch] = (trajectory, cache)
@@ -385,7 +385,7 @@ class RepresentationTracker:
     ) -> None:
         """Capture full representation snapshot for an epoch."""
 
-        traj, cache = self.wm.run_with_cache(observations)
+        _, _, cache = self.wm.run_with_cache(observations)
 
         snapshot = {}
 

--- a/world_model_lens/analysis/faithfulness.py
+++ b/world_model_lens/analysis/faithfulness.py
@@ -102,7 +102,7 @@ class FaithfulnessAnalyzer:
         Returns:
             AOPCResult with score and perturbation data.
         """
-        _, cache = self.wm.run_with_cache(observations, actions)
+        _, _, cache = self.wm.run_with_cache(observations, actions)
 
         original = cache[target_component]
 
@@ -158,7 +158,7 @@ class FaithfulnessAnalyzer:
                 return_cache=True,
             )
             if isinstance(hooked_result, tuple):
-                _, cache_ablated = hooked_result
+                cache_ablated = hooked_result[-1]
             else:
                 cache_ablated = None
 
@@ -256,7 +256,7 @@ class FaithfulnessAnalyzer:
         Returns:
             List of PerturbationResult for each K.
         """
-        _, cache = self.wm.run_with_cache(observations, actions)
+        _, _, cache = self.wm.run_with_cache(observations, actions)
 
         try:
             original = cache[target_component]
@@ -307,7 +307,7 @@ class FaithfulnessAnalyzer:
                 return_cache=True,
             )
             if isinstance(hooked_result, tuple):
-                _, cache_ablated = hooked_result
+                cache_ablated = hooked_result[-1]
             else:
                 cache_ablated = None
 

--- a/world_model_lens/analysis/layer_cka.py
+++ b/world_model_lens/analysis/layer_cka.py
@@ -180,7 +180,9 @@ class LayerCKAAnalyzer:
 
         # Run forward pass with caching
         with torch.no_grad():
-            traj, cache = self.wm.run_with_cache(observations, names_filter=block_hook_patterns)
+            _, _, cache = self.wm.run_with_cache(
+                observations, names_filter=block_hook_patterns
+            )
 
         # Extract layer outputs from cache
         layer_outputs = {}

--- a/world_model_lens/analysis/metrics.py
+++ b/world_model_lens/analysis/metrics.py
@@ -142,7 +142,7 @@ class LatentMetrics:
         Returns:
             MSE reconstruction error.
         """
-        traj, cache = wm.run_with_cache(obs, actions)
+        _, _, cache = wm.run_with_cache(obs, actions)
 
         try:
             recon = cache["reconstruction"]

--- a/world_model_lens/backends/toy_scientific_model.py
+++ b/world_model_lens/backends/toy_scientific_model.py
@@ -128,7 +128,7 @@ class ToyScientificAdapter(BaseModelAdapter):
         >>>
         >>> # Generate synthetic observations
         >>> observations = torch.randn(50, 10)  # 50 timesteps, 10D observations
-        >>> traj, cache = wm.run_with_cache(observations)
+        >>> world_traj, latent_traj, cache = wm.run_with_cache(observations)
     """
 
     def __init__(

--- a/world_model_lens/backends/toy_video_model.py
+++ b/world_model_lens/backends/toy_video_model.py
@@ -165,7 +165,7 @@ class ToyVideoAdapter(BaseModelAdapter):
         >>>
         >>> # Generate random video sequence
         >>> frames = torch.randn(10, 3, 64, 64)
-        >>> traj, cache = wm.run_with_cache(frames)
+        >>> world_traj, latent_traj, cache = wm.run_with_cache(frames)
     """
 
     def __init__(

--- a/world_model_lens/benchmarks/cartpole.py
+++ b/world_model_lens/benchmarks/cartpole.py
@@ -139,7 +139,7 @@ class CartPoleBenchmark:
         for obs in observations[:10]:
             if obs.dim() == 1:
                 obs = obs.unsqueeze(0)
-            traj, _ = self.wm.run_with_cache(obs.unsqueeze(0) if obs.dim() == 1 else obs)
+            traj, _, _ = self.wm.run_with_cache(obs.unsqueeze(0) if obs.dim() == 1 else obs)
             if traj.states:
                 z = traj.states[0].obs_encoding
                 if z is not None:
@@ -183,7 +183,7 @@ class CartPoleBenchmark:
         for obs in observations[:10]:
             if obs.dim() == 1:
                 obs = obs.unsqueeze(0)
-            traj, _ = self.wm.run_with_cache(obs.unsqueeze(0) if obs.dim() == 1 else obs)
+            traj, _, _ = self.wm.run_with_cache(obs.unsqueeze(0) if obs.dim() == 1 else obs)
             if traj.states:
                 z = traj.states[0].obs_encoding
                 if z is not None:
@@ -221,7 +221,7 @@ class CartPoleBenchmark:
         obs = torch.randn(50, 4)
 
         # Get baseline trajectory
-        baseline_traj, _ = self.wm.run_with_cache(obs)
+        baseline_traj, _, _ = self.wm.run_with_cache(obs)
 
         if velocity_dims is None:
             _, velocity_dims = self.find_velocity_encoding([obs])
@@ -273,7 +273,7 @@ class CartPoleBenchmark:
 
         # Generate latent trajectory for visualization
         test_obs = torch.randn(20, 4)
-        traj, _ = self.wm.run_with_cache(test_obs)
+        traj, _, _ = self.wm.run_with_cache(test_obs)
         latent_traj = torch.stack(
             [s.obs_encoding for s in traj.states if s.obs_encoding is not None]
         )

--- a/world_model_lens/benchmarks/continuous_control.py
+++ b/world_model_lens/benchmarks/continuous_control.py
@@ -108,7 +108,7 @@ class ContinuousControlBenchmark:
                 obs_short = traj[:horizon]
 
                 # Run model
-                pred_traj, _ = self.wm.run_with_cache(obs_short.unsqueeze(0))
+                pred_traj, _, _ = self.wm.run_with_cache(obs_short.unsqueeze(0))
 
                 # Compare final states
                 if len(pred_traj.states) > 0:

--- a/world_model_lens/benchmarks/gridworld.py
+++ b/world_model_lens/benchmarks/gridworld.py
@@ -123,7 +123,7 @@ class GridworldBenchmark:
         for traj_obs in trajectories[:20]:
             if traj_obs.dim() == 2:
                 traj_obs = traj_obs.unsqueeze(0)
-            traj, _ = self.wm.run_with_cache(traj_obs)
+            traj, _, _ = self.wm.run_with_cache(traj_obs)
 
             for state in traj.states:
                 z = state.obs_encoding if state.obs_encoding is not None else state.state
@@ -168,7 +168,7 @@ class GridworldBenchmark:
             # Goal info is in last 2 dimensions
             goal_signal = traj_obs[:, :, -2:].mean()
 
-            traj, _ = self.wm.run_with_cache(traj_obs)
+            traj, _, _ = self.wm.run_with_cache(traj_obs)
 
             for state in traj.states:
                 z = state.obs_encoding if state.obs_encoding is not None else state.state
@@ -218,7 +218,7 @@ class GridworldBenchmark:
         )[0]
 
         # Baseline
-        baseline_traj, _ = self.wm.run_with_cache(test_traj.unsqueeze(0))
+        baseline_traj, _, _ = self.wm.run_with_cache(test_traj.unsqueeze(0))
 
         if not memory_dims:
             return 0.0

--- a/world_model_lens/benchmarks/probing.py
+++ b/world_model_lens/benchmarks/probing.py
@@ -49,7 +49,7 @@ class ProbingBenchmarkSuite:
         Returns:
             R² score for reward prediction.
         """
-        traj, cache = wm.run_with_cache(observations, actions)
+        _, _, cache = wm.run_with_cache(observations, actions)
 
         try:
             z_posterior = cache["z_posterior"]
@@ -90,7 +90,7 @@ class ProbingBenchmarkSuite:
         Returns:
             R² score for value prediction.
         """
-        traj, cache = wm.run_with_cache(observations, actions)
+        _, _, cache = wm.run_with_cache(observations, actions)
 
         try:
             h = cache["h"]
@@ -129,7 +129,7 @@ class ProbingBenchmarkSuite:
         Returns:
             Accuracy for action prediction.
         """
-        traj, cache = wm.run_with_cache(observations, actions)
+        _, _, cache = wm.run_with_cache(observations, actions)
 
         try:
             z_prior = cache["z_prior"]
@@ -175,7 +175,7 @@ class ProbingBenchmarkSuite:
         Returns:
             Accuracy for state classification.
         """
-        traj, cache = wm.run_with_cache(observations, actions)
+        _, _, cache = wm.run_with_cache(observations, actions)
 
         try:
             z_posterior = cache["z_posterior"]
@@ -214,7 +214,7 @@ class ProbingBenchmarkSuite:
         Returns:
             R² score for temporal position prediction.
         """
-        traj, cache = wm.run_with_cache(observations, actions)
+        _, _, cache = wm.run_with_cache(observations, actions)
 
         try:
             h = cache["h"]

--- a/world_model_lens/benchmarks/suite.py
+++ b/world_model_lens/benchmarks/suite.py
@@ -341,8 +341,8 @@ class CircuitBenchmark(SyntheticBenchmark):
         clean_obs = torch.randn(20, d_obs)
         corrupted_obs = clean_obs + 0.5
 
-        traj_clean, cache_clean = hooked_wm.run_with_cache(clean_obs)
-        traj_corrupt, cache_corrupt = hooked_wm.run_with_cache(corrupted_obs)
+        traj_clean, _, cache_clean = hooked_wm.run_with_cache(clean_obs)
+        traj_corrupt, _, cache_corrupt = hooked_wm.run_with_cache(corrupted_obs)
 
         patcher = TemporalPatcher(hooked_wm)
         components = ["pos", "action_pred", "reward"]

--- a/world_model_lens/branching/brancher.py
+++ b/world_model_lens/branching/brancher.py
@@ -143,7 +143,7 @@ class ImaginationBrancher:
         branches = []
 
         for actions in action_sequences:
-            imagined = self.wm.imagine(
+            _, imagined = self.wm.imagine(
                 start_state=start_state,
                 actions=actions,
                 horizon=horizon,
@@ -186,7 +186,7 @@ class ImaginationBrancher:
         """
         start_state = real_traj.states[fork_at]
 
-        original = self.wm.imagine(
+        _, original = self.wm.imagine(
             start_state=start_state,
             actions=action_sequence,
             horizon=horizon,
@@ -198,7 +198,7 @@ class ImaginationBrancher:
         if z_replacement is not None:
             manipulated_state.z_posterior = z_replacement.clone()
 
-        manipulated = self.wm.imagine(
+        _, manipulated = self.wm.imagine(
             start_state=manipulated_state,
             actions=action_sequence,
             horizon=horizon,
@@ -281,7 +281,7 @@ class ImaginationBrancher:
         trajectories = []
 
         for _ in range(n_samples):
-            traj = self.wm.imagine(
+            _, traj = self.wm.imagine(
                 start_state=start_state,
                 horizon=horizon,
                 temperature=temperature,

--- a/world_model_lens/causal/counterfactual.py
+++ b/world_model_lens/causal/counterfactual.py
@@ -245,7 +245,7 @@ class CounterfactualEngine:
             timestep=intervention.target_timestep,
         )
 
-        cf_traj = self.wm.run_with_hooks(
+        cf_traj, _ = self.wm.run_with_hooks(
             observations=observations,
             actions=actions,
             fwd_hooks=[hook],
@@ -301,7 +301,7 @@ class CounterfactualEngine:
             BranchTree with all branches
         """
         # Get original trajectory
-        original_traj, _ = self.wm.run_with_cache(observations, base_actions)
+        original_traj, _, _ = self.wm.run_with_cache(observations, base_actions)
 
         tree = BranchTree(root_trajectory=original_traj)
 
@@ -373,7 +373,7 @@ class CounterfactualEngine:
             timestep=intervention.target_timestep,
         )
 
-        cf_traj = self.wm.run_with_hooks(
+        cf_traj, _ = self.wm.run_with_hooks(
             dummy_obs,
             actions=None,
             fwd_hooks=[hook],
@@ -400,7 +400,7 @@ class CounterfactualEngine:
             Dict mapping intervention index to metrics
         """
         # Get baseline
-        baseline_traj, _ = self.wm.run_with_cache(observations, base_actions)
+        baseline_traj, _, _ = self.wm.run_with_cache(observations, base_actions)
         baseline_outcome = self._extract_outcome(baseline_traj, target_metric)
 
         results = {}
@@ -454,7 +454,7 @@ class CounterfactualEngine:
         Returns:
             Critical timestep index
         """
-        baseline_traj, _ = self.wm.run_with_cache(observations)
+        baseline_traj, _, _ = self.wm.run_with_cache(observations)
 
         best_timestep = 0
         best_divergence = float("inf")

--- a/world_model_lens/causal/effect_estimator.py
+++ b/world_model_lens/causal/effect_estimator.py
@@ -177,7 +177,7 @@ class CausalEffectEstimator:
         """Run baseline without intervention."""
         outcomes = []
         for _ in range(self.num_samples):
-            traj, cache = self.wm.run_with_cache(observations, actions)
+            traj, _, cache = self.wm.run_with_cache(observations, actions)
             outcome = self._extract_target(traj, cache, "reward_pred")
             outcomes.append(outcome)
         return outcomes
@@ -374,7 +374,7 @@ class CausalEffectEstimator:
         if observations is None:
             observations = torch.randn(20, 64, 64, 3)
 
-        traj, cache = self.wm.run_with_cache(observations)
+        traj, _, cache = self.wm.run_with_cache(observations)
         z_sample = cache.get(("z_posterior", 0))
         if z_sample is None:
             z_sample = traj.states[0].state

--- a/world_model_lens/causal/trajectory_attribution.py
+++ b/world_model_lens/causal/trajectory_attribution.py
@@ -122,7 +122,7 @@ class TrajectoryAttribution:
         """
         # Get baseline trajectory
         observations = torch.randn(20, 3, 64, 64)
-        baseline_traj, baseline_cache = self.wm.run_with_cache(observations)
+        baseline_traj, _, baseline_cache = self.wm.run_with_cache(observations)
 
         # Get latent dimension
         z_sample = baseline_cache.get(("z_posterior", source_timestep))
@@ -232,7 +232,7 @@ class TrajectoryAttribution:
 
         # Get observations
         observations = torch.randn(trajectory_length, 3, 64, 64)
-        baseline_traj, baseline_cache = self.wm.run_with_cache(observations)
+        baseline_traj, _, baseline_cache = self.wm.run_with_cache(observations)
 
         # For each source timestep
         for source_t in range(trajectory_length):
@@ -271,7 +271,7 @@ class TrajectoryAttribution:
             Dict mapping timestep to effect magnitude
         """
         observations = torch.randn(20, 3, 64, 64)
-        baseline_traj, _ = self.wm.run_with_cache(observations)
+        baseline_traj, _, _ = self.wm.run_with_cache(observations)
 
         propagation = {}
 
@@ -312,7 +312,7 @@ class TrajectoryAttribution:
             Tensor of shape [len(timesteps), d_z, d_z]
         """
         observations = torch.randn(20, 3, 64, 64)
-        baseline_traj, _ = self.wm.run_with_cache(observations)
+        baseline_traj, _, _ = self.wm.run_with_cache(observations)
 
         z_sample = baseline_traj.states[0].state
         d_z = z_sample.shape[-1]
@@ -353,7 +353,7 @@ class TrajectoryAttribution:
             hook_specs={f"t={timestep}.z": pair_ablate},
         )
 
-        baseline_traj, _ = self.wm.run_with_cache(observations)
+        baseline_traj, _, _ = self.wm.run_with_cache(observations)
 
         baseline_outcome = self._extract_metric(baseline_traj, -1, metric)
         intervened_outcome = self._extract_metric(traj, -1, metric)

--- a/world_model_lens/core/hooked_root.py
+++ b/world_model_lens/core/hooked_root.py
@@ -71,7 +71,7 @@ class HookedRootModule(nn.Module):
                 self.setup_hooks()  # Must call to inject hooks
 
         wm = MyWorldModel(my_model)
-        cache = wm.run_with_cache(observations)
+        cache = wm.run_with_cache(observations)[-1]
 
         # Use standardized hook names
         z_hook = cache["dynamics.prior.hook_sample"]

--- a/world_model_lens/core/interpretability_hierarchy.py
+++ b/world_model_lens/core/interpretability_hierarchy.py
@@ -222,7 +222,7 @@ class InterpretabilityHierarchy:
         """
         from world_model_lens.causal.trajectory_attribution import TrajectoryAttribution
 
-        traj, _ = self.wm.run_with_cache(observations)
+        traj, _, _ = self.wm.run_with_cache(observations)
 
         T = len(traj.states)
 
@@ -355,7 +355,7 @@ class InterpretabilityHierarchy:
         Returns:
             Dict with all three levels of analysis
         """
-        traj, _ = self.wm.run_with_cache(observations)
+        traj, _, _ = self.wm.run_with_cache(observations)
 
         # Level 2: Examine state
         state_unit = self.examine_state(focus_timestep, traj)

--- a/world_model_lens/docs.py
+++ b/world_model_lens/docs.py
@@ -81,10 +81,10 @@ def quickstart():
     >>> # Run forward pass
     >>> import torch
     >>> obs = torch.randn(10, 3, 64, 64)
-    >>> traj, cache = wm.run_with_cache(obs)
+    >>> world_traj, latent_traj, cache = wm.run_with_cache(obs)
     >>>
     >>> # Analyze
-    >>> analysis = wm.analyze(traj, cache)
+    >>> analysis = wm.analyze(world_traj, cache)
     """
     pass
 

--- a/world_model_lens/envs/env_interface.py
+++ b/world_model_lens/envs/env_interface.py
@@ -147,7 +147,7 @@ class EpisodeCollector:
             metadata={"env_info": info, "total_reward": sum(reward_list)},
         )
 
-        traj, cache = self.wm.run_with_cache(obs_seq, action_seq)
+        _, traj, cache = self.wm.run_with_cache(obs_seq, action_seq)
 
         return traj, cache, {"total_reward": sum(reward_list), "length": t}
 

--- a/world_model_lens/envs/gymnasium_hooks.py
+++ b/world_model_lens/envs/gymnasium_hooks.py
@@ -75,7 +75,7 @@ class WorldModelEnv:
         obs = wm_env.reset()
 
         # Use imagination for planning
-        imagined = wm.imagine(wm_env.current_state, horizon=10)
+        imagined_world, imagined_latent = wm.imagine(wm_env.current_state, horizon=10)
 
         # Take real step
         action = wm_env.action_space.sample()
@@ -197,7 +197,7 @@ class WorldModelEnv:
 
         if self._cache is not None:
             try:
-                traj, cache = self.wm.run_with_cache(
+                _, _, cache = self.wm.run_with_cache(
                     obs_tensor.unsqueeze(0),
                     actions=torch.tensor([action]).to(self._device).unsqueeze(0)
                     if action.shape
@@ -262,8 +262,12 @@ class WorldModelEnv:
         if actions is not None:
             actions = torch.from_numpy(actions).float().to(self._device)
 
-        trajectory = self.wm.imagine(
-            start_state=None,
+        from world_model_lens.core.latent_state import LatentState
+
+        start_state = LatentState(h_t=h.clone(), z_posterior=z.clone(), z_prior=z.clone())
+
+        _, trajectory = self.wm.imagine(
+            start_state=start_state,
             actions=actions,
             horizon=horizon,
         )
@@ -303,8 +307,12 @@ class WorldModelEnv:
             if actions is not None:
                 actions_tensor = torch.from_numpy(actions).float().to(self._device)
 
-                trajectory = self.wm.imagine(
-                    start_state=None,
+                from world_model_lens.core.latent_state import LatentState
+
+                start_state = LatentState(h_t=h.clone(), z_posterior=z.clone(), z_prior=z.clone())
+
+                _, trajectory = self.wm.imagine(
+                    start_state=start_state,
                     actions=actions_tensor,
                     horizon=horizon,
                 )

--- a/world_model_lens/hooked_world_model.py
+++ b/world_model_lens/hooked_world_model.py
@@ -12,7 +12,6 @@ if TYPE_CHECKING:
     from world_model_lens.core.world_state import WorldState, WorldTrajectory, WorldDynamics
     from world_model_lens.core.world_trajectory import WorldTrajectory
     from world_model_lens.core.config import WorldModelConfig
-    from world_model_lens.core.latent_state import LatentState
 
 from world_model_lens.core.hooks import HookContext, HookPoint, HookRegistry
 from world_model_lens.core.activation_cache import ActivationCache
@@ -21,6 +20,7 @@ from world_model_lens.core.world_trajectory import WorldTrajectory
 from world_model_lens.backends.base_adapter import WorldModelCapabilities
 from world_model_lens.core.hook_cache import HookCacheManager
 from world_model_lens.core.forward_runner import ForwardRunner
+from world_model_lens.core.latent_state import LatentState
 from world_model_lens.core.latent_trajectory import LatentTrajectory
 from world_model_lens.core.types import WorldModelFamily
 
@@ -54,8 +54,10 @@ class HookedWorldModel:
         >>>
         >>> # Wrap and use
         >>> wm = HookedWorldModel(adapter=MyModel(config), config=config)
-        >>> traj, cache = wm.run_with_cache(observations)
-        >>> imagined = wm.imagine(start_state=traj.states[0], horizon=20)
+        >>> world_traj, latent_traj, cache = wm.run_with_cache(observations)
+        >>> imagined_world, imagined_latent = wm.imagine(
+        ...     start_state=latent_traj.states[0], horizon=20
+        ... )
     """
 
     def __init__(
@@ -295,7 +297,7 @@ class HookedWorldModel:
         names_filter: Optional[set] = None,
         device: Optional[torch.device] = None,
         store_logits: bool = True,
-    ) -> Tuple[WorldTrajectory, ActivationCache]:
+    ) -> Tuple[WorldTrajectory, LatentTrajectory, ActivationCache]:
         """Run forward pass with full activation caching.
 
         This method is backend-agnostic. It works with any world model
@@ -313,7 +315,7 @@ class HookedWorldModel:
             store_logits: Whether to store logits (for probing)
 
         Returns:
-            Tuple of (WorldTrajectory, ActivationCache)
+            Tuple of (WorldTrajectory, LatentTrajectory, ActivationCache)
         """
         # normalize names_filter to a set for efficient membership tests
         # normalize names_filter to a set[str] for efficient membership checks
@@ -321,7 +323,8 @@ class HookedWorldModel:
 
         T = observations.shape[0]
         cache = ActivationCache()
-        states = []
+        world_states = []
+        latent_states = []
 
         caps = self._get_capabilities()
 
@@ -351,11 +354,12 @@ class HookedWorldModel:
                 names_filter,
                 no_grad=True,
             )
-            traj = self._latent_traj_to_world_traj(latent_traj)
+            world_traj = self._latent_traj_to_world_traj(latent_traj)
             if device:
-                traj = traj.to_device(device)
+                world_traj = world_traj.to_device(device)
+                latent_traj = latent_traj.to_device(device)
                 cache = cache.to_device(device)
-            return traj, cache
+            return world_traj, latent_traj, cache
 
         init_result = self.adapter.initial_state(batch_size=1, device=observations.device)
         if isinstance(init_result, tuple):
@@ -374,7 +378,7 @@ class HookedWorldModel:
             if actions is not None and t < len(actions):
                 action = actions[t]
 
-            hook_ctx = HookContext(timestep=t, component="state", trajectory_so_far=states)
+            hook_ctx = HookContext(timestep=t, component="state", trajectory_so_far=latent_states)
             # apply hooks and cache via central helper
             state = self._apply_and_cache("state", t, state, hook_ctx, cache, names_filter)
 
@@ -383,7 +387,9 @@ class HookedWorldModel:
             )
             posterior = posterior.squeeze(0)
 
-            hook_ctx_z = HookContext(timestep=t, component="z_posterior", trajectory_so_far=states)
+            hook_ctx_z = HookContext(
+                timestep=t, component="z_posterior", trajectory_so_far=latent_states
+            )
             posterior = self._apply_and_cache(
                 "z_posterior", t, posterior, hook_ctx_z, cache, names_filter
             )
@@ -404,7 +410,7 @@ class HookedWorldModel:
                 "z_prior",
                 t,
                 prior,
-                HookContext(timestep=t, component="z_prior", trajectory_so_far=states),
+                HookContext(timestep=t, component="z_prior", trajectory_so_far=latent_states),
                 cache,
                 names_filter,
             )
@@ -413,7 +419,9 @@ class HookedWorldModel:
                     "observation",
                     t,
                     obs_encoding,
-                    HookContext(timestep=t, component="observation", trajectory_so_far=states),
+                    HookContext(
+                        timestep=t, component="observation", trajectory_so_far=latent_states
+                    ),
                     cache,
                     names_filter,
                 )
@@ -428,7 +436,7 @@ class HookedWorldModel:
                 manager.apply_kv_hooks(
                     cache,
                     t,
-                    HookContext(timestep=t, component="kv_cache", trajectory_so_far=states),
+                    HookContext(timestep=t, component="kv_cache", trajectory_so_far=latent_states),
                 )
 
             # Check for optional target encoder (e.g. for I-JEPA/JEPA models)
@@ -441,7 +449,9 @@ class HookedWorldModel:
                         t,
                         target_encoding,
                         HookContext(
-                            timestep=t, component="target_encoding", trajectory_so_far=states
+                            timestep=t,
+                            component="target_encoding",
+                            trajectory_so_far=latent_states,
                         ),
                         cache,
                         names_filter,
@@ -459,7 +469,9 @@ class HookedWorldModel:
                             "reward",
                             t,
                             reward_pred.squeeze(0),
-                            HookContext(timestep=t, component="reward", trajectory_so_far=states),
+                            HookContext(
+                                timestep=t, component="reward", trajectory_so_far=latent_states
+                            ),
                             cache,
                             names_filter,
                         )
@@ -489,7 +501,9 @@ class HookedWorldModel:
                             "value",
                             t,
                             value_pred.squeeze(0),
-                            HookContext(timestep=t, component="value", trajectory_so_far=states),
+                            HookContext(
+                                timestep=t, component="value", trajectory_so_far=latent_states
+                            ),
                             cache,
                             names_filter,
                         )
@@ -508,7 +522,7 @@ class HookedWorldModel:
                     "kl",
                     t,
                     kl,
-                    HookContext(timestep=t, component="kl", trajectory_so_far=states),
+                    HookContext(timestep=t, component="kl", trajectory_so_far=latent_states),
                     cache,
                     names_filter,
                 )
@@ -525,7 +539,9 @@ class HookedWorldModel:
                             t,
                             recon.squeeze(0),
                             HookContext(
-                                timestep=t, component="reconstruction", trajectory_so_far=states
+                                timestep=t,
+                                component="reconstruction",
+                                trajectory_so_far=latent_states,
                             ),
                             cache,
                             names_filter,
@@ -535,7 +551,9 @@ class HookedWorldModel:
 
             action_for_transition = action if caps.uses_actions else None
             if action_for_transition is not None:
-                hook_ctx_a = HookContext(timestep=t, component="action", trajectory_so_far=states)
+                hook_ctx_a = HookContext(
+                    timestep=t, component="action", trajectory_so_far=latent_states
+                )
                 action_for_transition = self._hooks.apply(
                     "action", t, action_for_transition, hook_ctx_a
                 )
@@ -552,10 +570,10 @@ class HookedWorldModel:
             transition_ctx = HookContext(
                 timestep=t,
                 component="transition",
-                trajectory_so_far=states,
+                trajectory_so_far=latent_states,
                 metadata={
                     "s_t": state.clone(),  # Current state after transition
-                    "s_prev": states[-1].state if states else None,  # Previous state
+                    "s_prev": world_states[-1].state if world_states else None,  # Previous state
                     "a_t": action_for_transition,  # Action used
                     "z_t": posterior,  # Latent encoding
                 },
@@ -572,7 +590,9 @@ class HookedWorldModel:
                     temperature=None,
                 )
 
-            state_obj = WorldState(
+            # Build both public trajectory views at the same timestep so
+            # environment-facing and model-facing consumers stay aligned.
+            world_state = WorldState(
                 state=state.clone(),
                 timestep=t,
                 action=action_for_state,
@@ -581,21 +601,37 @@ class HookedWorldModel:
                 value_pred=value_pred.squeeze(0).clone() if value_pred is not None else None,
                 obs_encoding=obs_encoding.clone() if obs_encoding is not None else None,
             )
-            states.append(state_obj)
+            world_states.append(world_state)
+
+            latent_state = LatentState(
+                h_t=state.clone(),
+                z_posterior=posterior.clone(),
+                z_prior=prior.clone(),
+                timestep=t,
+                action=action_for_state.clone() if action_for_state is not None else None,
+                reward_pred=reward_pred.squeeze(0).clone() if reward_pred is not None else None,
+                cont_pred=None,
+                value_pred=value_pred.squeeze(0).clone() if value_pred is not None else None,
+                actor_logits=None,
+                obs_encoding=obs_encoding.clone() if obs_encoding is not None else None,
+            )
+            latent_states.append(latent_state)
 
             if z_current is not None:
                 z_current = posterior
 
-        traj = WorldTrajectory(
-            states=states,
+        world_traj = WorldTrajectory(
+            states=world_states,
             source="real",
         )
+        latent_traj = LatentTrajectory(states=latent_states, env_name=self.name, imagined=False)
 
         if device:
-            traj = traj.to_device(device)
+            world_traj = world_traj.to_device(device)
+            latent_traj = latent_traj.to_device(device)
             cache = cache.to_device(device)
 
-        return traj, cache
+        return world_traj, latent_traj, cache
 
     def run_with_hooks(
         self,
@@ -603,7 +639,10 @@ class HookedWorldModel:
         actions: Optional[torch.Tensor] = None,
         fwd_hooks: Optional[Union[List[HookPoint], Tuple[HookPoint, ...]]] = None,
         return_cache: bool = False,
-    ) -> Union[WorldTrajectory, Tuple[WorldTrajectory, ActivationCache]]:
+    ) -> Union[
+        Tuple[WorldTrajectory, LatentTrajectory],
+        Tuple[WorldTrajectory, LatentTrajectory, ActivationCache],
+    ]:
         """Run forward pass with temporary hooks.
 
         Hooks fire after each activation is computed but before it feeds
@@ -616,7 +655,7 @@ class HookedWorldModel:
             return_cache: If True, also return ActivationCache
 
         Returns:
-            WorldTrajectory, or (WorldTrajectory, ActivationCache) if return_cache
+            (WorldTrajectory, LatentTrajectory), or that pair plus ActivationCache
         """
         cache: ActivationCache | None = ActivationCache() if return_cache else None
 
@@ -624,37 +663,46 @@ class HookedWorldModel:
         # and cleaned up automatically, even if the forward pass raises.
         # coerce names_filter absent -> None handled by run_with_cache
         with self._hooks.temp_hooks(list(fwd_hooks) if fwd_hooks else []):
-            traj, cache = self.run_with_cache(observations, actions)
+            world_traj, latent_traj, cache = self.run_with_cache(observations, actions)
 
         if return_cache:
-            return traj, cache
-        return traj
+            return world_traj, latent_traj, cache
+        return world_traj, latent_traj
 
     def imagine(
         self,
-        start_state: WorldState,
+        start_state: Union[WorldState, LatentState],
         actions: Optional[torch.Tensor] = None,
         horizon: int = 50,
         temperature: float = 1.0,
-    ) -> WorldTrajectory:
+    ) -> Tuple[WorldTrajectory, LatentTrajectory]:
         """Imagine forward from a starting state using dynamics model.
 
         Works with ANY world model - RL and non-RL. For non-RL models,
         actions are ignored.
 
         Args:
-            start_state: Starting WorldState
+            start_state: Starting WorldState or LatentState
             actions: Optional action sequence to execute (ignored for non-RL models)
             horizon: Number of imagination steps
             temperature: Sampling temperature for discrete states
 
         Returns:
-            Imagined WorldTrajectory
+            Tuple of (WorldTrajectory, LatentTrajectory)
         """
         caps = self._get_capabilities()
-        state = start_state.state.clone()
-        z = start_state.obs_encoding if start_state.obs_encoding is not None else state
-        states = [start_state]
+        # Accept either world-facing or latent-facing start states so
+        # callers can branch from the representation they already have.
+        if isinstance(start_state, LatentState):
+            state = start_state.h_t.clone()
+            z = start_state.z_posterior.clone()
+            start_timestep = start_state.timestep
+        else:
+            state = start_state.state.clone()
+            z = start_state.obs_encoding if start_state.obs_encoding is not None else state
+            start_timestep = start_state.timestep
+        world_states = []
+        latent_states = []
 
         for t in range(horizon):
             action = None
@@ -715,9 +763,9 @@ class HookedWorldModel:
 
             # Apply transition hook for causality analysis
             transition_ctx = HookContext(
-                timestep=t + start_state.timestep + 1,
+                timestep=t + start_timestep + 1,
                 component="transition",
-                trajectory_so_far=states,
+                trajectory_so_far=latent_states,
                 metadata={
                     "s_t": state.clone(),  # Current state after transition
                     "s_prev": prev_state,  # Previous state
@@ -726,7 +774,7 @@ class HookedWorldModel:
                 },
             )
             state = self._hooks.apply(
-                "transition", t + start_state.timestep + 1, state, transition_ctx
+                "transition", t + start_timestep + 1, state, transition_ctx
             )
 
             reward_pred = None
@@ -737,20 +785,37 @@ class HookedWorldModel:
                 except NotImplementedError:
                     pass
 
-            state_obj = WorldState(
+            world_state = WorldState(
                 state=state.clone(),
-                timestep=t + start_state.timestep + 1,
+                timestep=t + start_timestep + 1,
                 action=action.clone() if action is not None else None,
                 action_source=action_source,
                 reward_pred=reward_pred,
             )
-            states.append(state_obj)
+            world_states.append(world_state)
 
-        return WorldTrajectory(
-            states=states[1:],
+            latent_state = LatentState(
+                h_t=state.clone(),
+                z_posterior=z.clone(),
+                z_prior=z.clone(),
+                timestep=t + start_timestep + 1,
+                action=action.clone() if action is not None else None,
+                reward_pred=reward_pred.clone() if reward_pred is not None else None,
+            )
+            latent_states.append(latent_state)
+
+        world_traj = WorldTrajectory(
+            states=world_states,
             source="imagined",
-            fork_point=start_state.timestep,
+            fork_point=start_timestep,
         )
+        latent_traj = LatentTrajectory(
+            states=latent_states,
+            env_name=self.name,
+            imagined=True,
+            fork_point=start_timestep,
+        )
+        return world_traj, latent_traj
 
     def add_hook(self, hook: HookPoint) -> None:
         """Add a persistent hook."""

--- a/world_model_lens/patching/advanced_patching.py
+++ b/world_model_lens/patching/advanced_patching.py
@@ -359,12 +359,12 @@ def estimate_planning_horizon(
     """
     from world_model_lens import HookedWorldModel
 
-    traj, cache = model.run_with_cache(obs_seq, torch.zeros(obs_seq.shape[0], 4))
+    traj, _, cache = model.run_with_cache(obs_seq, torch.zeros(obs_seq.shape[0], 4))
     start_state = traj.states[-1]
 
     fidelities = {}
     for h in range(1, min(max_horizon + 1, len(real_future_obs))):
-        imagined = model.imagine(start_state, horizon=h)
+        imagined, _ = model.imagine(start_state, horizon=h)
         imagined_obs = torch.stack(
             [s.obs_encoding for s in imagined.states if s.obs_encoding is not None], dim=0
         )
@@ -410,7 +410,7 @@ def belief_drift_rollout(
     kl_per_timestep = defaultdict(list)
 
     for _ in range(n_samples):
-        rollout = model.imagine(start_state, horizon=horizon)
+        rollout, _ = model.imagine(start_state, horizon=horizon)
 
         for i, state in enumerate(rollout.states):
             if hasattr(state, "kl") and state.kl is not None:

--- a/world_model_lens/patching/attribution.py
+++ b/world_model_lens/patching/attribution.py
@@ -639,7 +639,7 @@ class AdvancedCausalTracer:
 
         corrupt_hook = self.wm.hook_builder.ablate_dims(corrupt_dims, corrupt_value)
 
-        clean_traj, clean_cache = self.wm.run_with_cache(observations)
+        clean_traj, _, clean_cache = self.wm.run_with_cache(observations)
 
         corrupted_traj = self.wm.run_with_advanced_hooks(
             observations,
@@ -681,7 +681,7 @@ class AdvancedCausalTracer:
 
         patch_fn = patch_fn or default_patch
 
-        clean_traj, _ = self.wm.run_with_cache(observations)
+        clean_traj, _, _ = self.wm.run_with_cache(observations)
 
         corrupted_traj = self.wm.run_with_advanced_hooks(
             observations,
@@ -720,7 +720,7 @@ class AdvancedCausalTracer:
 
         patch_fn = patch_fn or default_patch
 
-        clean_traj, _ = self.wm.run_with_cache(observations)
+        clean_traj, _, _ = self.wm.run_with_cache(observations)
 
         intervened_traj = self.wm.run_with_advanced_hooks(
             observations,

--- a/world_model_lens/patching/patcher.py
+++ b/world_model_lens/patching/patcher.py
@@ -238,7 +238,7 @@ class TemporalPatcher:
             if clean_obs_seq is not None and clean_action_seq is not None:
                 obs_seq = self._ensure_device(clean_obs_seq)
                 action_seq = self._ensure_device(clean_action_seq)
-                patched_traj, patched_cache = self.wm.run_with_cache(obs_seq, action_seq)
+                patched_traj, _, patched_cache = self.wm.run_with_cache(obs_seq, action_seq)
                 patched_metric = self.compute_metric_from_cache(
                     patched_cache, patch_component, metric_fn
                 )
@@ -293,7 +293,7 @@ class TemporalPatcher:
         clean_obs = self._ensure_device(clean_obs_seq)
         clean_actions = self._ensure_device(clean_action_seq)
 
-        clean_traj, clean_cache = self.wm.run_with_cache(clean_obs, clean_actions)
+        clean_traj, _, clean_cache = self.wm.run_with_cache(clean_obs, clean_actions)
         clean_metric = self.compute_metric_from_trajectory(clean_traj, metric_fn)
 
         corrupted_cache = ActivationCache()
@@ -326,7 +326,7 @@ class TemporalPatcher:
         self.wm.add_hook(hook)
 
         try:
-            corrupted_traj, _ = self.wm.run_with_cache(clean_obs, clean_actions)
+            corrupted_traj, _, _ = self.wm.run_with_cache(clean_obs, clean_actions)
             corrupted_metric = self.compute_metric_from_trajectory(corrupted_traj, metric_fn)
         finally:
             self.wm.clear_hooks()
@@ -341,7 +341,7 @@ class TemporalPatcher:
         self.wm.add_hook(hook2)
 
         try:
-            patched_traj, _ = self.wm.run_with_cache(clean_obs, clean_actions)
+            patched_traj, _, _ = self.wm.run_with_cache(clean_obs, clean_actions)
             patched_metric = self.compute_metric_from_trajectory(patched_traj, metric_fn)
         finally:
             self.wm.clear_hooks()

--- a/world_model_lens/sae/sae.py
+++ b/world_model_lens/sae/sae.py
@@ -544,7 +544,7 @@ class SAELayer:
         Returns:
             Tuple of (trajectory, cache)
         """
-        traj, cache = self.wm.run_with_cache(observations, actions)
+        _, traj, cache = self.wm.run_with_cache(observations, actions)
 
         feature_activations = self.get_feature_activations(cache)
         self._feature_cache = feature_activations

--- a/world_model_lens/safety/__init__.py
+++ b/world_model_lens/safety/__init__.py
@@ -171,7 +171,7 @@ def compute_safety_score(
 
     for traj in test_trajectories:
         try:
-            imagined = wm.imagine(traj.states[-1], horizon=min(20, len(traj)))
+            _, imagined = wm.imagine(traj.states[-1], horizon=min(20, len(traj)))
 
             divergence = []
             for i in range(min(len(traj), len(imagined))):
@@ -256,7 +256,7 @@ class SafetyChecker:
 
         if imagined_traj is None:
             try:
-                imagined_traj = self.wm.imagine(traj.states[-1], horizon=len(traj))
+                _, imagined_traj = self.wm.imagine(traj.states[-1], horizon=len(traj))
             except Exception as e:
                 results["issues"].append(f"Could not generate imagination: {str(e)}")
                 return results

--- a/world_model_lens/safety/analyzer.py
+++ b/world_model_lens/safety/analyzer.py
@@ -86,7 +86,7 @@ class SafetyAnalyzer:
             ]
         ).to(self.device)
 
-        traj, cache = self.wm.run_with_cache(observations=observations)
+        traj, _, cache = self.wm.run_with_cache(observations=observations)
 
         findings.extend(self._check_ood_detection(traj, cache))
         findings.extend(self._check_dynamics_stability(traj, cache))

--- a/world_model_lens/scalability/parallel.py
+++ b/world_model_lens/scalability/parallel.py
@@ -92,7 +92,7 @@ def _worker_process_chunk(
         obs = traj_data["observation"]
         actions = traj_data.get("actions")
 
-        traj, cache = wm.run_with_cache(
+        _, _, cache = wm.run_with_cache(
             obs.to(device),
             actions.to(device) if actions is not None else None,
             names_filter=names_filter,
@@ -117,7 +117,7 @@ def _run_single_worker(
         obs = traj.h_sequence.to(device)
         actions = traj.actions.to(device) if traj.actions is not None else None
 
-        traj_out, cache = wm.run_with_cache(
+        _, _, cache = wm.run_with_cache(
             obs,
             actions,
             names_filter=names_filter,

--- a/world_model_lens/visualization/intervention_plots.py
+++ b/world_model_lens/visualization/intervention_plots.py
@@ -28,7 +28,7 @@ class InterventionVisualizer:
 
         # Get original and intervened trajectories
         obs = torch.randn(20, 3, 64, 64)
-        traj, _ = world_model.run_with_cache(obs)
+        traj, _, _ = world_model.run_with_cache(obs)
 
         # Create intervention
         def ablate_hook(tensor, ctx):

--- a/world_model_lens/visualization/latent_plots.py
+++ b/world_model_lens/visualization/latent_plots.py
@@ -27,7 +27,7 @@ class LatentTrajectoryPlotter:
 
         # Generate trajectory
         obs = torch.randn(20, 3, 64, 64)
-        traj, cache = world_model.run_with_cache(obs)
+        world_traj, traj, cache = world_model.run_with_cache(obs)
 
         # PCA projection
         pca = plotter.project_pca(traj, n_components=2)

--- a/world_model_lens/visualization/prediction_plots.py
+++ b/world_model_lens/visualization/prediction_plots.py
@@ -29,13 +29,13 @@ class PredictionVisualizer:
 
         # Get predictions and ground truth
         obs = torch.randn(10, 3, 64, 64)
-        traj, cache = world_model.run_with_cache(obs)
+        world_traj, latent_traj, cache = world_model.run_with_cache(obs)
 
         # Compare reconstructions
-        comp = viz.compare_reconstructions(traj, cache, observations=obs)
+        comp = viz.compare_reconstructions(world_traj, cache, observations=obs)
 
         # Error heatmap
-        errors = viz.error_heatmap(traj, cache)
+        errors = viz.error_heatmap(world_traj, cache)
 
         # Per-frame comparison
         frames = viz.plot_frame_comparison(traj, cache, frame_idx=5)

--- a/world_model_lens/visualization/temporal_maps.py
+++ b/world_model_lens/visualization/temporal_maps.py
@@ -97,7 +97,7 @@ class TemporalAttributionMap:
         T = observations.shape[0]
 
         # Get baseline
-        baseline_traj, _ = self.wm.run_with_cache(observations, actions)
+        baseline_traj, _, _ = self.wm.run_with_cache(observations, actions)
 
         influence = np.zeros((T, T))
 
@@ -109,7 +109,7 @@ class TemporalAttributionMap:
                 stage="post",
                 fn=_make_ablate_hook(source_t),
             )
-            intervened_traj = self.wm.run_with_hooks(
+            intervened_traj, _ = self.wm.run_with_hooks(
                 observations, actions, fwd_hooks=[hp],
             )
 
@@ -149,14 +149,14 @@ class TemporalAttributionMap:
         """
         T = observations.shape[0]
 
-        baseline_traj, _ = self.wm.run_with_cache(observations, actions)
+        baseline_traj, _, _ = self.wm.run_with_cache(observations, actions)
 
         hp = HookPoint(
             name="z_posterior",
             stage="post",
             fn=_make_ablate_hook(source_t),
         )
-        intervened_traj = self.wm.run_with_hooks(
+        intervened_traj, _ = self.wm.run_with_hooks(
             observations, actions, fwd_hooks=[hp],
         )
 
@@ -187,7 +187,7 @@ class TemporalAttributionMap:
         """
         T = observations.shape[0]
 
-        baseline_traj, _ = self.wm.run_with_cache(observations, actions)
+        baseline_traj, _, _ = self.wm.run_with_cache(observations, actions)
 
         target_baseline = self._extract_metric(baseline_traj, target_t, "state_norm")
 
@@ -199,7 +199,7 @@ class TemporalAttributionMap:
                 stage="post",
                 fn=_make_ablate_hook(source_t),
             )
-            intervened_traj = self.wm.run_with_hooks(
+            intervened_traj, _ = self.wm.run_with_hooks(
                 observations, actions, fwd_hooks=[hp],
             )
 
@@ -228,7 +228,7 @@ class TemporalAttributionMap:
         Returns:
             Dict mapping intermediate timesteps to their importance
         """
-        baseline_traj, _ = self.wm.run_with_cache(observations, actions)
+        baseline_traj, _, _ = self.wm.run_with_cache(observations, actions)
 
         baseline_target = self._extract_metric(baseline_traj, target_t, "state_norm")
 
@@ -241,7 +241,7 @@ class TemporalAttributionMap:
                 stage="post",
                 fn=_make_multi_ablate_hook(source_t, mid_t),
             )
-            intervened_traj = self.wm.run_with_hooks(
+            intervened_traj, _ = self.wm.run_with_hooks(
                 observations, actions, fwd_hooks=[hp],
             )
 


### PR DESCRIPTION
Closes #28.

run_with_cache() now returns world_traj, latent_traj, cache and imagine() now returns imagined_world_traj, imagined_latent_traj.

This keeps environment-facing and model-facing trajectory data separate instead of overloading WorldTrajectory to do both jobs. JEPA and downstream callers were updated to follow the same contract, and examples/docs were updated as well.

Validation: source .venv/bin/activate && pytest tests -q
Result: 305 passed, 1 skipped, 3 deselected