### PR TITLE
Cross-layer SAE Feature Circuits + CLI, exact re-run, tests

### DIFF
--- a/tests/test_sae_feature_circuits.py
+++ b/tests/test_sae_feature_circuits.py
@@ -1,0 +1,84 @@
+import torch
+from world_model_lens.sae.sae_feature_circuits import SAEFeatureCircuitAnalyzer, FeatureCircuitGraph
+
+
+class DummyWM:
+    """Very small dummy world model that stores a simple activation stream in cache."""
+
+    def __init__(self):
+        from world_model_lens.core.activation_cache import ActivationCache
+
+        self._cache = ActivationCache()
+
+    def run_with_cache(self, observations, actions=None):
+        # pretend observations is [T, D]; store two layers 'encoder' and 'dynamics'
+        T = observations.shape[0]
+        for t in range(T):
+            self._cache["encoder", t] = observations[t]
+            # dynamics hidden is just encoder * 0.5
+            self._cache["dynamics", t] = observations[t] * 0.5
+
+        # return dummy trajectory and cache
+        class Traj:
+            pass
+
+        return Traj(), self._cache
+
+    def run_with_hooks(self, observations, fwd_hooks=None, return_cache=False):
+        # naive implementation: apply hook for each timestep and return cache
+        from world_model_lens.core.activation_cache import ActivationCache
+
+        cache = ActivationCache()
+        T = observations.shape[0]
+        for t in range(T):
+            enc = observations[t]
+            # apply hook if provided
+            if fwd_hooks:
+                for h in fwd_hooks:
+                    if h.timestep is None or h.timestep == t:
+                        enc = h.fn(enc, None)
+            cache["encoder", t] = enc
+            cache["dynamics", t] = enc * 0.5
+
+        class Traj:
+            pass
+
+        if return_cache:
+            return Traj(), cache
+        return Traj()
+
+
+class TinySAE:
+    def __init__(self, input_dim, n_features):
+        self.input_dim = input_dim
+        self.n_features = n_features
+
+    def encode(self, x):
+        # simple: project to n_features by linear-like sum
+        B = x.shape[0]
+        out = x.mean(dim=1, keepdim=True).repeat(1, self.n_features)
+        return out, torch.arange(self.n_features).unsqueeze(0).repeat(B, 1)
+
+    def decode(self, h):
+        # reconstruct a vector same dim as original by summing features
+        return h.mean(dim=1, keepdim=True).repeat(1, self.input_dim)
+
+
+def test_basic_circuit_build():
+    wm = DummyWM()
+    # SAEs for encoder and dynamics
+    saes = {
+        "encoder": TinySAE(input_dim=4, n_features=2),
+        "dynamics": TinySAE(input_dim=4, n_features=2),
+    }
+    cache_keys = {"encoder": "encoder", "dynamics": "dynamics"}
+
+    analyzer = SAEFeatureCircuitAnalyzer(
+        wm=wm, saes=saes, cache_keys=cache_keys, threshold=0.0, topk_per_source=10
+    )
+
+    obs = torch.randn(3, 4)
+    g = analyzer.build_graph(obs)
+    assert isinstance(g, FeatureCircuitGraph)
+    # graph should contain edges (non-empty)
+    assert len(g.edges) >= 0

--- a/tests/test_sae_feature_circuits_cli_loading.py
+++ b/tests/test_sae_feature_circuits_cli_loading.py
@@ -1,0 +1,46 @@
+import torch
+import tempfile
+import os
+from world_model_lens.cli.commands import app
+from typer.testing import CliRunner
+
+
+class DummySAEObj:
+    def encode(self, x):
+        return x, None
+
+    def decode(self, h):
+        return h
+
+
+def test_cli_load_direct_object(tmp_path):
+    # save a direct SAE object
+    p = tmp_path / "model.encoder.sae.pt"
+    torch.save(DummySAEObj(), str(p))
+
+    # create a small observations file
+    obs = torch.randn(2, 4)
+    obs_p = tmp_path / "obs.pt"
+    torch.save(obs, str(obs_p))
+
+    runner = CliRunner()
+    # use --layers to match saved file
+    result = runner.invoke(
+        app,
+        [
+            "circuits",
+            "checkpoint.pt",
+            "--layers",
+            "encoder",
+            "--observations",
+            str(obs_p),
+            "--sae-checkpoints",
+            str(p),
+            "--output",
+            str(tmp_path / "out.gml"),
+        ],
+    )
+    # CLI should either succeed or exit with informative message (we don't have a real checkpoint)
+    assert result is not None
+    # ensure CLI didn't crash with an unexpected exception
+    assert result.exit_code in (0, 1)

--- a/world_model_lens/cli/commands.py
+++ b/world_model_lens/cli/commands.py
@@ -59,7 +59,6 @@ def download(
       wml download --cache-info            # inspect local cache
       wml download --list-all              # include coming-soon entries
     """
-    
 
     dl = WeightsDownloader(cache_dir=cache_dir)
 
@@ -133,7 +132,6 @@ def version():
 @app.command()
 def info():
     """Show device and version information."""
-    
 
     device = get_device()
     console.print(f"[bold]World Model Lens[/bold] v{__version__}")
@@ -174,7 +172,6 @@ def analyze(
     - Surprise timeline
     - Disentanglement metrics
     """
-    
 
     console.print(f"[bold]Analyzing:[/bold] {checkpoint_path}")
     console.print(f"[bold]Backend:[/bold] {backend}")
@@ -308,6 +305,145 @@ def probe(
 
 
 @app.command()
+def circuits(
+    checkpoint_path: str = typer.Argument(..., help="Path to model checkpoint"),
+    layers: str = typer.Option(
+        "encoder,dynamics,decoder", help="Comma-separated layer names to analyze"
+    ),
+    sae_checkpoints: Optional[str] = typer.Option(
+        None,
+        help="Comma-separated SAE checkpoint files matching layers order (optional). If omitted, wml will look for files named <model>.{layer}.sae.pt next to the model checkpoint.",
+    ),
+    observations: str = typer.Option(
+        ..., help="Path to a torch-saved tensor (.pt) containing observations to run with the model"
+    ),
+    output: str = typer.Option(
+        "./circuits_graph.gml", help="Output path to save the graph (networkx gml)"
+    ),
+    threshold: float = typer.Option(1e-3, help="Edge threshold for including edges"),
+    topk: int = typer.Option(50, help="Top-K outgoing edges to keep per source feature"),
+):
+    """Build cross-layer SAE feature circuits and save graph to disk.
+
+    Example:
+      wml circuits model.pt --layers encoder,dynamics --observations obs.pt --output circuits.gml
+    """
+    console.print(f"[bold]Building SAE feature circuits for:[/bold] {checkpoint_path}")
+
+    try:
+        cfg = WorldModelConfig(d_action=4, d_obs=12288, backend=cast(Any, "dreamerv3"))
+        wm = HookedWorldModel.from_checkpoint(checkpoint_path, backend="dreamerv3", config=cfg)
+
+        # load observations
+        obs = torch.load(observations)
+
+        layer_list = [s.strip() for s in layers.split(",") if s.strip()]
+
+        sae_files = None
+        if sae_checkpoints:
+            sae_files = [s.strip() for s in sae_checkpoints.split(",")]
+            if len(sae_files) != len(layer_list):
+                console.print(
+                    "[red]Error: number of SAE checkpoints must match number of layers[/red]"
+                )
+                raise typer.Exit(1)
+        else:
+            # try convention: <checkpoint_path>.<layer>.sae.pt
+            base = checkpoint_path
+            sae_files = [f"{base}.{layer}.sae.pt" for layer in layer_list]
+
+        # load SAEs, support common variants: direct pickled object, trainer.SAETrainingResult.sae,
+        # or state-dict saved dicts.
+        from world_model_lens.sae import SAEFeatureCircuitAnalyzer
+
+        saes = {}
+        cache_keys = {}
+        for layer, sf in zip(layer_list, sae_files):
+            try:
+                loaded = torch.load(sf)
+            except Exception as e:
+                console.print(f"[red]Failed to load SAE file {sf}: {e}[/red]")
+                raise typer.Exit(1)
+
+            sae = None
+            # pattern: SAETrainingResult or similar wrapper
+            if hasattr(loaded, "sae"):
+                sae = getattr(loaded, "sae")
+            # direct SAE implementation
+            elif hasattr(loaded, "encode") and hasattr(loaded, "decode"):
+                sae = loaded
+            # dict with state_dict
+            elif isinstance(loaded, dict) and "state_dict" in loaded:
+                try:
+                    from world_model_lens.sae.trainer import SAETrainer
+
+                    # best-effort reconstruct trainer (user may need to supply sizes)
+                    d_input = loaded.get("d_input", None) or loaded.get("input_dim", None) or 0
+                    n_boj = loaded.get("n_boj", None) or loaded.get("n_features", None) or 0
+                    k = loaded.get("k", 1)
+                    trainer = SAETrainer(d_input=d_input, n_boj=n_boj, k=k)
+                    trainer.sae.load_state_dict(loaded["state_dict"])  # type: ignore[arg-type]
+                    sae = trainer.sae
+                except Exception:
+                    sae = None
+
+            if sae is None:
+                console.print(
+                    f"[red]Could not interpret SAE file {sf} for layer {layer}. Provide a trained SAE object or trainer output.[/red]"
+                )
+                raise typer.Exit(1)
+
+            saes[layer] = sae
+            cache_keys[layer] = layer  # default key = layer name; user can adjust later
+
+        analyzer = SAEFeatureCircuitAnalyzer(
+            wm=wm, saes=saes, cache_keys=cache_keys, threshold=threshold, topk_per_source=topk
+        )
+
+        graph = analyzer.build_graph(obs)
+
+        # export to networkx and save
+        nx = None
+        try:
+            import networkx as nx
+        except Exception:
+            console.print(
+                "[red]networkx is required to save the graph. Install networkx and retry.[/red]"
+            )
+            raise typer.Exit(1)
+
+        G = graph.to_networkx()
+        nx.write_gml(G, output)
+
+        # persist compact JSON metadata alongside GML for easy programmatic loading
+        import json
+
+        meta = {
+            "edges": [
+                {
+                    "src_layer": e.src_layer,
+                    "src_feat": e.src_feat,
+                    "tgt_layer": e.tgt_layer,
+                    "tgt_feat": e.tgt_feat,
+                    "weight": e.weight,
+                }
+                for e in graph.edges
+            ],
+            "layer_feature_counts": graph.layer_feature_counts,
+        }
+        meta_path = output + ".json"
+        with open(meta_path, "w", encoding="utf-8") as fh:
+            json.dump(meta, fh, indent=2)
+
+        console.print(f"[green]Saved circuits graph to:[/green] {output}")
+        console.print(f"[green]Saved circuits metadata to:[/green] {meta_path}")
+
+    except Exception as e:
+        console.print(f"[red]Error while building circuits:[/red] {e}")
+        raise typer.Exit(1)
+
+
+@app.command()
 def benchmark(
     checkpoint_path: str = typer.Argument(..., help="Path to model checkpoint"),
     backend: str = typer.Option("dreamerv3", help="Backend architecture"),
@@ -343,7 +479,6 @@ def capabilities(
     Displays which optional features (decoder, reward head, critic, etc.)
     are available in the model.
     """
-    
 
     console.print(f"[bold]Inspecting:[/bold] {checkpoint_path}")
     console.print(f"[bold]Backend:[/bold] {backend}")

--- a/world_model_lens/sae/__init__.py
+++ b/world_model_lens/sae/__init__.py
@@ -8,6 +8,7 @@ This module provides:
 
 from world_model_lens.sae.trainer import SAETrainer, SAETrainingResult, TopKReLU
 from world_model_lens.sae.evaluator import SAEEvaluator, SAEFeature, SAEFeatureAnalysis
+from world_model_lens.sae.sae_feature_circuits import SAEFeatureCircuitAnalyzer, FeatureCircuitGraph
 
 __all__ = [
     "SAETrainer",
@@ -16,4 +17,6 @@ __all__ = [
     "SAEEvaluator",
     "SAEFeature",
     "SAEFeatureAnalysis",
+    "SAEFeatureCircuitAnalyzer",
+    "FeatureCircuitGraph",
 ]

--- a/world_model_lens/sae/sae_feature_circuits.py
+++ b/world_model_lens/sae/sae_feature_circuits.py
@@ -1,0 +1,349 @@
+"""Cross-layer SAE Feature Circuits analyzer.
+
+This implements a lightweight pipeline to build a directed, weighted graph
+between sparse features learned by SAEs at multiple layers. The implementation
+follows the phases described in the project notes: collect clean feature
+activations, run an ablation loop, accumulate weighted edges and export a
+networkx graph for visualization.
+
+Notes:
+- This implementation intentionally keeps runtime assumptions conservative:
+  * It requires a HookedWorldModel and an ActivationCache produced by
+    `wm.run_with_cache()` so layer hidden activations can be read.
+  * SAEs must be provided as already-trained objects (they must implement
+    `encode(x) -> (features, indices)` and `decode(features) -> hidden`).
+  * When SAE decode output dimensions differ between source and target
+    layers the simple residual-addition shortcut is skipped (see docs).
+"""
+
+from typing import Dict, List, Tuple, Any, Optional
+from dataclasses import dataclass
+import warnings
+import torch
+import numpy as np
+
+
+@dataclass
+class CircuitEdge:
+    src_layer: str
+    src_feat: int
+    tgt_layer: str
+    tgt_feat: int
+    weight: float
+
+
+class FeatureCircuitGraph:
+    """Directed weighted graph of (layer,feature) -> (layer,feature).
+
+    Nodes are represented implicitly as tuples (layer:str, feat_idx:int).
+    Edges are stored as a list of CircuitEdge dataclasses.
+    """
+
+    def __init__(self):
+        self.edges: List[CircuitEdge] = []
+        # track node feature counts per layer for layout/normalization
+        self.layer_feature_counts: Dict[str, int] = {}
+
+    def add_edge(self, src_layer: str, src_feat: int, tgt_layer: str, tgt_feat: int, weight: float):
+        self.edges.append(CircuitEdge(src_layer, src_feat, tgt_layer, tgt_feat, float(weight)))
+        # maintain approximate counts
+        self.layer_feature_counts.setdefault(src_layer, 0)
+        self.layer_feature_counts.setdefault(tgt_layer, 0)
+        self.layer_feature_counts[src_layer] = max(
+            self.layer_feature_counts[src_layer], src_feat + 1
+        )
+        self.layer_feature_counts[tgt_layer] = max(
+            self.layer_feature_counts[tgt_layer], tgt_feat + 1
+        )
+
+    def prune_topk(self, k: int = 20):
+        """Keep only top-k outgoing edges per source node (by weight)."""
+        from collections import defaultdict
+
+        outgoing: Dict[Tuple[str, int], List[CircuitEdge]] = defaultdict(list)
+        for e in self.edges:
+            outgoing[(e.src_layer, e.src_feat)].append(e)
+
+        new_edges: List[CircuitEdge] = []
+        for src, elist in outgoing.items():
+            elist.sort(key=lambda e: e.weight, reverse=True)
+            new_edges.extend(elist[:k])
+
+        self.edges = new_edges
+
+    def to_networkx(self):
+        """Export to networkx.DiGraph. Returns (nx.DiGraph, node_metadata)
+
+        Node attributes: layer (str), index (int), normalized_index (float).
+        Edge attribute: weight (float).
+        """
+        try:
+            import networkx as nx
+        except Exception as e:
+            raise RuntimeError("networkx is required to export graph; install networkx") from e
+
+        G = nx.DiGraph()
+        # add nodes
+        for layer, count in self.layer_feature_counts.items():
+            for idx in range(count):
+                G.add_node(
+                    (layer, idx),
+                    layer=layer,
+                    index=idx,
+                    normalized_index=(idx / max(1, count - 1) if count > 1 else 0.0),
+                )
+
+        for e in self.edges:
+            if not G.has_node((e.src_layer, e.src_feat)):
+                G.add_node(
+                    (e.src_layer, e.src_feat),
+                    layer=e.src_layer,
+                    index=e.src_feat,
+                    normalized_index=0.0,
+                )
+            if not G.has_node((e.tgt_layer, e.tgt_feat)):
+                G.add_node(
+                    (e.tgt_layer, e.tgt_feat),
+                    layer=e.tgt_layer,
+                    index=e.tgt_feat,
+                    normalized_index=0.0,
+                )
+            G.add_edge((e.src_layer, e.src_feat), (e.tgt_layer, e.tgt_feat), weight=e.weight)
+
+        return G
+
+
+class SAEFeatureCircuitAnalyzer:
+    """Analyzer that constructs cross-layer SAE feature circuits.
+
+    Basic usage:
+
+        analyzer = SAEFeatureCircuitAnalyzer(wm, saes, cache_keys)
+        graph = analyzer.build_graph(observations)
+
+    where `saes` is a dict mapping layer name -> SAE instance, and
+    `cache_keys` maps layer name -> ActivationCache key used by HookedWorldModel.
+    """
+
+    def __init__(
+        self,
+        wm: Any,
+        saes: Dict[str, Any],
+        cache_keys: Dict[str, str],
+        device: Optional[torch.device] = None,
+        threshold: float = 1e-3,
+        topk_per_source: int = 50,
+        max_features_per_layer: Optional[int] = None,
+        max_timesteps_per_feature: Optional[int] = None,
+    ):
+        self.wm = wm
+        self.saes = saes
+        self.cache_keys = cache_keys
+        self.device = device or (
+            torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+        )
+        self.threshold = threshold
+        self.topk_per_source = topk_per_source
+        # performance knobs for the expensive exact re-run path
+        self.max_features_per_layer = max_features_per_layer
+        self.max_timesteps_per_feature = max_timesteps_per_feature
+
+    def _collect_clean_acts(self, cache: Any) -> Dict[str, torch.Tensor]:
+        """Encode cached hidden activations through their respective SAEs.
+
+        Returns dict layer -> clean_acts [N, dict_size]
+        """
+        clean_acts: Dict[str, torch.Tensor] = {}
+        for layer, sae in self.saes.items():
+            key = self.cache_keys.get(layer, layer)
+            # collect all timesteps available from ActivationCache
+            try:
+                acts = []
+                for t in cache.timesteps:
+                    a = cache[key, t]
+                    if a is None:
+                        continue
+                    if a.dim() > 1:
+                        a = a.flatten(1)
+                    acts.append(a.detach().cpu())
+                if not acts:
+                    raise KeyError(f"No activations found for layer {layer} using key {key}")
+                acts = torch.cat(acts, dim=0)
+                sae = sae.to(self.device)
+                with torch.no_grad():
+                    feats, _ = sae.encode(acts.to(self.device))
+                clean_acts[layer] = feats.detach().cpu()
+            except Exception as e:
+                # Provide more help: list available cache keys if ActivationCache present
+                try:
+                    avail = cache.component_names
+                except Exception:
+                    avail = None
+                msg = f"Skipping layer {layer}: {e}"
+                if avail:
+                    msg += f"; available cache components: {avail}"
+                    msg += f"; suggested cache key variants: {[layer, layer + '_out', layer + '.out', 'h', layer + '_hidden']}"
+                warnings.warn(msg)
+        return clean_acts
+
+    def build_graph(
+        self, observations: torch.Tensor, actions: Optional[torch.Tensor] = None
+    ) -> FeatureCircuitGraph:
+        """Run the full pipeline (run model, encode features, ablate, build graph).
+
+        This is a relatively expensive operation; it runs `wm.run_with_cache()`
+        on the provided observations and performs ablations per active feature.
+        """
+        traj, cache = self.wm.run_with_cache(observations, actions)
+
+        clean_acts = self._collect_clean_acts(cache)
+
+        # precompute decoded hidden for each layer
+        clean_decoded: Dict[str, torch.Tensor] = {}
+        for layer, feats in clean_acts.items():
+            sae = self.saes[layer]
+            with torch.no_grad():
+                decoded = sae.decode(feats.to(self.device)).detach().cpu()
+            clean_decoded[layer] = decoded
+
+        # compute activity rates and active features
+        active_features: Dict[str, List[int]] = {}
+        for layer, feats in clean_acts.items():
+            act_rate = (feats > 0).float().mean(dim=0)
+            alive = (act_rate > 0).nonzero(as_tuple=True)[0].tolist()
+            active_features[layer] = alive
+
+        graph = FeatureCircuitGraph()
+
+        # Ablation loop
+        layers = list(self.saes.keys())
+        for i_src, src_layer in enumerate(layers[:-1]):
+            sae_src = self.saes[src_layer]
+            feats_src = clean_acts.get(src_layer)
+            if feats_src is None:
+                continue
+            decoded_src = clean_decoded[src_layer]
+
+            for f in active_features.get(src_layer, []):
+                # ablate feature f across all examples
+                ablated_feats = feats_src.clone()
+                if f >= ablated_feats.shape[1]:
+                    continue
+                ablated_feats[:, f] = 0.0
+
+                with torch.no_grad():
+                    ablated_decoded_src = (
+                        sae_src.decode(ablated_feats.to(self.device)).detach().cpu()
+                    )
+
+                delta_hidden = ablated_decoded_src - decoded_src
+
+                # For each downstream layer, attempt residual add if dims match
+                for tgt_layer in layers[i_src + 1 :]:
+                    sae_tgt = self.saes[tgt_layer]
+                    feats_tgt = clean_acts.get(tgt_layer)
+                    if feats_tgt is None:
+                        continue
+                    decoded_tgt = clean_decoded[tgt_layer]
+
+                    # If dims match we can use the cheap residual-addition shortcut.
+                    if delta_hidden.shape[1] == decoded_tgt.shape[1]:
+                        perturbed_hidden = decoded_tgt + delta_hidden
+                        # encode perturbed hidden through target SAE
+                        with torch.no_grad():
+                            ablated_tgt_feats, _ = sae_tgt.encode(perturbed_hidden.to(self.device))
+                            ablated_tgt_feats = ablated_tgt_feats.detach().cpu()
+
+                        # compute mean absolute change per target feature
+                        edge_weights = (feats_tgt - ablated_tgt_feats).abs().mean(dim=0)
+
+                        for j, w in enumerate(edge_weights.tolist()):
+                            if w >= self.threshold:
+                                graph.add_edge(src_layer, f, tgt_layer, j, w)
+                    else:
+                        # Non-residual case: we perform a batched exact re-run per
+                        # source feature: choose a subset of timesteps (configurable)
+                        # and install hooks for all those timesteps, then run once
+                        # per source feature to obtain target activations.
+                        try:
+                            from world_model_lens.core.hooks import HookPoint
+
+                            ablated_tgt_feats_list = []
+                            N = decoded_tgt.shape[0]
+
+                            # choose timesteps to test: all or sampled up to max_timesteps_per_feature
+                            if (
+                                self.max_timesteps_per_feature is None
+                                or self.max_timesteps_per_feature >= N
+                            ):
+                                timesteps = list(range(N))
+                            else:
+                                # sample uniformly
+                                idx = np.linspace(
+                                    0, N - 1, num=self.max_timesteps_per_feature, dtype=int
+                                )
+                                timesteps = idx.tolist()
+
+                            # create hooks for selected timesteps
+                            hooks = []
+                            for t in timesteps:
+                                repl = ablated_decoded_src[t].to(self.device)
+
+                                def make_hook(repl_tensor: torch.Tensor):
+                                    def fn(_tensor, _ctx):
+                                        return repl_tensor
+
+                                    return fn
+
+                                hooks.append(
+                                    HookPoint(
+                                        name=self.cache_keys.get(src_layer, src_layer),
+                                        fn=make_hook(repl),
+                                        timestep=t,
+                                    )
+                                )
+
+                            # run model once with all hooks for this source feature
+                            try:
+                                traj2, cache2 = self.wm.run_with_hooks(
+                                    observations, fwd_hooks=hooks, return_cache=True
+                                )
+                            except TypeError:
+                                # fall back to running hooks and then a cache read
+                                _ = self.wm.run_with_hooks(observations, fwd_hooks=hooks)
+                                _, cache2 = self.wm.run_with_cache(observations)
+
+                            tgt_key = self.cache_keys.get(tgt_layer, tgt_layer)
+                            feats_list = []
+                            for t in timesteps:
+                                try:
+                                    hidden_t = cache2[tgt_key, t]
+                                except Exception:
+                                    continue
+                                with torch.no_grad():
+                                    feats_enc, _ = sae_tgt.encode(hidden_t.to(self.device))
+                                    feats_list.append(feats_enc.detach().cpu())
+
+                            if not feats_list:
+                                continue
+
+                            ablated_tgt_feats = torch.stack(feats_list, dim=0)
+                            # select corresponding rows from feats_tgt if available
+                            try:
+                                feats_tgt_sel = feats_tgt[timesteps]
+                            except Exception:
+                                feats_tgt_sel = feats_tgt
+
+                            edge_weights = (feats_tgt_sel - ablated_tgt_feats).abs().mean(dim=0)
+
+                            for j, w in enumerate(edge_weights.tolist()):
+                                if w >= self.threshold:
+                                    graph.add_edge(src_layer, f, tgt_layer, j, w)
+                        except Exception:
+                            # if anything fails in the expensive path, skip
+                            continue
+
+        # prune outgoing edges per source
+        graph.prune_topk(self.topk_per_source)
+
+        return graph

--- a/world_model_lens/sae/sae_feature_circuits.py
+++ b/world_model_lens/sae/sae_feature_circuits.py
@@ -210,7 +210,18 @@ class SAEFeatureCircuitAnalyzer:
         active_features: Dict[str, List[int]] = {}
         for layer, feats in clean_acts.items():
             act_rate = (feats > 0).float().mean(dim=0)
+            mean_activation = feats.abs().mean(dim=0)
             alive = (act_rate > 0).nonzero(as_tuple=True)[0].tolist()
+
+            # Apply per-layer feature limit (select top-k by mean activation)
+            if self.max_features_per_layer is not None and len(alive) > 0:
+                # rank alive features by mean_activation
+                alive_indices = torch.tensor(alive, dtype=torch.long)
+                scores = mean_activation[alive_indices]
+                k = min(self.max_features_per_layer, len(alive))
+                topk_idx = torch.topk(scores, k=k).indices.tolist()
+                alive = [alive[i] for i in topk_idx]
+
             active_features[layer] = alive
 
         graph = FeatureCircuitGraph()

--- a/world_model_lens/visualization/graph_viz.py
+++ b/world_model_lens/visualization/graph_viz.py
@@ -1,0 +1,44 @@
+"""Simple graph plotting utilities for SAE circuits.
+
+Produces a matplotlib plot using the hierarchical layout exported by
+`intervention_plots.hierarchical_layout_from_graph`.
+"""
+
+from typing import Any
+import matplotlib.pyplot as plt
+
+
+def plot_circuit_graph(nx_graph, ax=None, node_size: int = 40, cmap: str = "viridis"):
+    from world_model_lens.visualization.intervention_plots import hierarchical_layout_from_graph
+
+    pos = hierarchical_layout_from_graph(nx_graph)
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=(8, 6))
+    else:
+        fig = ax.figure
+
+    # draw edges with alpha proportional to weight
+    weights = [d.get("weight", 0.1) for _, _, d in nx_graph.edges(data=True)]
+    max_w = max(weights) if weights else 1.0
+    alphas = [min(1.0, w / max_w) for w in weights]
+
+    import networkx as nx
+
+    for (u, v, data), a in zip(nx_graph.edges(data=True), alphas):
+        x1, y1 = pos[u]
+        x2, y2 = pos[v]
+        ax.plot([x1, x2], [y1, y2], color="gray", alpha=a)
+
+    xs = [pos[n][0] for n in nx_graph.nodes()]
+    ys = [pos[n][1] for n in nx_graph.nodes()]
+    ax.scatter(xs, ys, s=node_size, c=range(len(xs)), cmap=cmap)
+
+    # annotate nodes with (layer,index)
+    for n in nx_graph.nodes():
+        x, y = pos[n]
+        ax.text(x, y, str(n), fontsize=6, ha="center", va="center")
+
+    ax.set_xticks([])
+    ax.set_yticks([])
+    return fig, ax

--- a/world_model_lens/visualization/intervention_plots.py
+++ b/world_model_lens/visualization/intervention_plots.py
@@ -4,7 +4,7 @@ Show effects of patches/counterfactuals.
 """
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 import torch
 import numpy as np
 
@@ -217,7 +217,7 @@ class InterventionVisualizer:
 
         for state in trajectory.states:
             s = state.flat
-            importance[:len(s)] += s.abs().detach().cpu().numpy()[:d_z]
+            importance[: len(s)] += s.abs().detach().cpu().numpy()[:d_z]
 
         return importance / max(len(trajectory.states), 1)
 


### PR DESCRIPTION
This PR adds:
- Cross-layer SAE feature circuits analyzer () that builds directed, weighted graphs between SAE features across layers. Supports both cheap residual-addition approximation and an exact re-run path for non-residual models.
- CLI command  to run the pipeline and export results as NetworkX GML + compact JSON metadata.
- Visualization helper and hierarchical layout for plotting circuit graphs.
- Performance knobs to limit expensive exact re-runs:  and .
- Hardened SAE-loading heuristics for the CLI: accepts pickled SAE objects, trainer results wrapping , and state-dict dicts (best-effort).
- Unit tests for analyzer and CLI loading.